### PR TITLE
Create app options menu

### DIFF
--- a/app/components/AppOptions/AppOptions.module.css
+++ b/app/components/AppOptions/AppOptions.module.css
@@ -1,4 +1,5 @@
 .app_options {
+    user-select: none;
     background-color: aqua;
 }
 

--- a/app/components/AppOptions/AppOptions.module.css
+++ b/app/components/AppOptions/AppOptions.module.css
@@ -1,4 +1,6 @@
 .app_options {
+    display: flex;
+    flex-direction: column;
     user-select: none;
     background-color: aqua;
 }
@@ -12,4 +14,10 @@
 
 .app_options > ul {
     list-style-type: none;
+}
+
+.apply_defaults {
+    align-self: center;
+    cursor: pointer;
+    background-color: pink;
 }

--- a/app/components/AppOptions/AppOptions.module.css
+++ b/app/components/AppOptions/AppOptions.module.css
@@ -1,0 +1,3 @@
+.app_options {
+    background-color: aqua;
+}

--- a/app/components/AppOptions/AppOptions.module.css
+++ b/app/components/AppOptions/AppOptions.module.css
@@ -1,3 +1,14 @@
 .app_options {
     background-color: aqua;
 }
+
+.app_options > header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.app_options > ul {
+    list-style-type: none;
+}

--- a/app/components/AppOptions/AppOptions.module.css
+++ b/app/components/AppOptions/AppOptions.module.css
@@ -1,8 +1,13 @@
 .app_options {
     display: flex;
     flex-direction: column;
+    padding: 8px 16px 16px;
+    gap: 8px;
+    min-width: 400px;
     user-select: none;
-    background-color: aqua;
+    font-family: var(--font-family-main);
+    background-color: var(--dark3);
+    border-radius: 20px;
 }
 
 .app_options > header {
@@ -10,14 +15,24 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    font-size: var(--font-size-l);
 }
 
 .app_options > ul {
+    display: flex;
+    flex-direction: column;
     list-style-type: none;
+    gap: 6px;
+}
+
+.horizontal_divider {
+    height: 2px;
+    background-color: var(--dark6);
 }
 
 .apply_defaults {
     align-self: center;
     cursor: pointer;
-    background-color: pink;
+    font-size: var(--font-size-m);
+    color: var(--accent1);
 }

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -4,6 +4,7 @@ import OptionLine from './OptionLine';
 
 export interface appOptionDataIF {
     text: string;
+    isDefault: boolean;
 }
 
 interface propsIF {
@@ -16,42 +17,54 @@ export default function AppOptions(props: propsIF) {
     const optionsTop: appOptionDataIF[] = [
         {
             text: 'Skip Open Order Confirmations',
+            isDefault: false,
         },
         {
             text: 'Skip Close Position Confirmations',
+            isDefault: false,
         },
         {
             text: 'Opt Out of Spot Dusting',
+            isDefault: false,
         },
         {
             text: 'Persist Trading Connection',
+            isDefault: false,
         },
     ];
 
     const optionsBottom: appOptionDataIF[] = [
         {
             text: 'Display Verbose Errors',
+            isDefault: false,
         },
         {
             text: 'Disable Background Fill Notifications',
+            isDefault: false,
         },
         {
             text: 'Disable Playing Sound for Fills',
+            isDefault: true,
         },
         {
             text: 'Animate Order Book',
+            isDefault: true,
         },
         {
             text: 'Order Book Set Size on Click',
+            isDefault: true,
         },
         {
             text: 'Show Buys and Sells on Chart',
+            isDefault: true,
         },
         {
             text: 'Hide PnL',
+            isDefault: false,
         },
         {
             text: 'Show All Warnings',
+            isDefault: true,
         },
     ];
 

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,7 +1,8 @@
 import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
+import OptionLine from './OptionLine';
 
-interface appOptionDataIF {
+export interface appOptionDataIF {
     text: string;
 }
 
@@ -65,7 +66,10 @@ export default function AppOptions(props: propsIF) {
                 {
                     optionsTop.map(
                         (option: appOptionDataIF) => (
-                            <li key={JSON.stringify(option)}>{option.text}</li>
+                            <OptionLine
+                                key={JSON.stringify(option)}
+                                option={option}
+                            />
                         )
                     )
                 }
@@ -75,7 +79,10 @@ export default function AppOptions(props: propsIF) {
                 {
                     optionsBottom.map(
                         (option: appOptionDataIF) => (
-                            <li key={JSON.stringify(option)}>{option.text}</li>
+                            <OptionLine
+                                key={JSON.stringify(option)}
+                                option={option}
+                            />
                         )
                     )
                 }

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -91,6 +91,11 @@ export default function AppOptions(props: propsIF) {
         },
     ];
 
+    function clickConfirm(): void {
+        localStorage.setItem('APP_OPTIONS', JSON.stringify(checked));
+        modalControl.close();
+    }
+
     return (
         <section className={styles.app_options}>
             <header>
@@ -127,7 +132,7 @@ export default function AppOptions(props: propsIF) {
             </ul>
             <footer>
                 <button onClick={modalControl.close}>Cancel</button>
-                <button>Confirm</button>
+                <button onClick={clickConfirm}>Confirm</button>
             </footer>
         </section>
     );

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -9,6 +9,72 @@ export interface appOptionDataIF {
     isDefault: boolean;
 }
 
+const optionsTop: appOptionDataIF[] = [
+    {
+        slug: 'skipOpenOrderConfirm',
+        text: 'Skip Open Order Confirmations',
+        isDefault: false,
+    },
+    {
+        slug: 'skipClosePositionConfirm',
+        text: 'Skip Close Position Confirmations',
+        isDefault: false,
+    },
+    {
+        slug: 'optOutOfSpotDusting',
+        text: 'Opt Out of Spot Dusting',
+        isDefault: false,
+    },
+    {
+        slug: 'persistTradingConnection',
+        text: 'Persist Trading Connection',
+        isDefault: false,
+    },
+];
+
+const optionsBottom: appOptionDataIF[] = [
+    {
+        slug: 'displayVerboseErrors',
+        text: 'Display Verbose Errors',
+        isDefault: false,
+    },
+    {
+        slug: 'disableBackgroundFillNotif',
+        text: 'Disable Background Fill Notifications',
+        isDefault: false,
+    },
+    {
+        slug: 'disableFillSound',
+        text: 'Disable Playing Sound for Fills',
+        isDefault: true,
+    },
+    {
+        slug: 'animateOrderBook',
+        text: 'Animate Order Book',
+        isDefault: true,
+    },
+    {
+        slug: 'orderBookSetSizeOnClk',
+        text: 'Order Book Set Size on Click',
+        isDefault: true,
+    },
+    {
+        slug: 'showBuysSellsOnChart',
+        text: 'Show Buys and Sells on Chart',
+        isDefault: true,
+    },
+    {
+        slug: 'hidePnL',
+        text: 'Hide PnL',
+        isDefault: false,
+    },
+    {
+        slug: 'showAllWarnings',
+        text: 'Show All Warnings',
+        isDefault: true,
+    },
+];
+
 interface propsIF {
     modalControl: useModalIF;
 }
@@ -16,7 +82,7 @@ interface propsIF {
 export default function AppOptions(props: propsIF) {
     const { modalControl } = props;
 
-    const [checked, setChecked] = useState<string[]>([]);
+    const [checked, setChecked] = useState<string[]>(initializeData());
     function toggleChecked(item: string) {
         const updated: string[] = checked.includes(item)
             ? checked.filter((c: string) => c !== item)
@@ -25,71 +91,18 @@ export default function AppOptions(props: propsIF) {
         setChecked(updated);
     }
 
-    const optionsTop: appOptionDataIF[] = [
-        {
-            slug: 'skipOpenOrderConfirm',
-            text: 'Skip Open Order Confirmations',
-            isDefault: false,
-        },
-        {
-            slug: 'skipClosePositionConfirm',
-            text: 'Skip Close Position Confirmations',
-            isDefault: false,
-        },
-        {
-            slug: 'optOutOfSpotDusting',
-            text: 'Opt Out of Spot Dusting',
-            isDefault: false,
-        },
-        {
-            slug: 'persistTradingConnection',
-            text: 'Persist Trading Connection',
-            isDefault: false,
-        },
-    ];
-
-    const optionsBottom: appOptionDataIF[] = [
-        {
-            slug: 'displayVerboseErrors',
-            text: 'Display Verbose Errors',
-            isDefault: false,
-        },
-        {
-            slug: 'disableBackgroundFillNotif',
-            text: 'Disable Background Fill Notifications',
-            isDefault: false,
-        },
-        {
-            slug: 'disableFillSound',
-            text: 'Disable Playing Sound for Fills',
-            isDefault: true,
-        },
-        {
-            slug: 'animateOrderBook',
-            text: 'Animate Order Book',
-            isDefault: true,
-        },
-        {
-            slug: 'orderBookSetSizeOnClk',
-            text: 'Order Book Set Size on Click',
-            isDefault: true,
-        },
-        {
-            slug: 'showBuysSellsOnChart',
-            text: 'Show Buys and Sells on Chart',
-            isDefault: true,
-        },
-        {
-            slug: 'hidePnL',
-            text: 'Hide PnL',
-            isDefault: false,
-        },
-        {
-            slug: 'showAllWarnings',
-            text: 'Show All Warnings',
-            isDefault: true,
-        },
-    ];
+    function initializeData(): string[] {
+        let initialData: string[];
+        const persisted: string|null = localStorage.getItem('APP_OPTIONS');
+        if (persisted) {
+            initialData = JSON.parse(persisted);
+        } else {
+            initialData = optionsTop.concat(optionsBottom)
+                .filter((opt: appOptionDataIF) => opt.isDefault)
+                .flatMap((opt: appOptionDataIF) => opt.slug);
+        }
+        return initialData;
+    }
 
     function clickConfirm(): void {
         localStorage.setItem('APP_OPTIONS', JSON.stringify(checked));

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,8 +1,10 @@
 import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
+import { useState } from 'react';
 
 export interface appOptionDataIF {
+    slug: string;
     text: string;
     isDefault: boolean;
 }
@@ -13,21 +15,26 @@ interface propsIF {
 
 export default function AppOptions(props: propsIF) {
     const { modalControl } = props;
+    
 
     const optionsTop: appOptionDataIF[] = [
         {
+            slug: 'skipOpenOrderConfirm',
             text: 'Skip Open Order Confirmations',
             isDefault: false,
         },
         {
+            slug: 'skipClosePositionConfirm',
             text: 'Skip Close Position Confirmations',
             isDefault: false,
         },
         {
+            slug: 'optOutOfSpotDusting',
             text: 'Opt Out of Spot Dusting',
             isDefault: false,
         },
         {
+            slug: 'persistTradingConnection',
             text: 'Persist Trading Connection',
             isDefault: false,
         },
@@ -35,34 +42,42 @@ export default function AppOptions(props: propsIF) {
 
     const optionsBottom: appOptionDataIF[] = [
         {
+            slug: 'displayVerboseErrors',
             text: 'Display Verbose Errors',
             isDefault: false,
         },
         {
+            slug: 'disableBackgroundFillNotif',
             text: 'Disable Background Fill Notifications',
             isDefault: false,
         },
         {
+            slug: 'disableFillSound',
             text: 'Disable Playing Sound for Fills',
             isDefault: true,
         },
         {
+            slug: 'animateOrderBook',
             text: 'Animate Order Book',
             isDefault: true,
         },
         {
+            slug: 'orderBookSetSizeOnClk',
             text: 'Order Book Set Size on Click',
             isDefault: true,
         },
         {
+            slug: 'showBuysSellsOnChart',
             text: 'Show Buys and Sells on Chart',
             isDefault: true,
         },
         {
+            slug: 'hidePnL',
             text: 'Hide PnL',
             isDefault: false,
         },
         {
+            slug: 'showAllWarnings',
             text: 'Show All Warnings',
             isDefault: true,
         },

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -81,11 +81,6 @@ export default function AppOptions(props: propsIF) {
         shouldToggleOnClose.current = output;
     }
 
-    function clickConfirm(): void {
-        activeOptions.toggle(shouldToggleOnClose.current);
-        modalControl.close();
-    }
-
     return (
         <section className={styles.app_options}>
             <header>
@@ -100,8 +95,8 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isEnabled={activeOptions[option.slug]}
-                                markForUpdate={() => markForUpdate(option.slug)}
+                                isChecked={activeOptions[option.slug]}
+                                toggle={() => activeOptions.toggle(option.slug)}
                             />
                         )
                     )
@@ -115,17 +110,13 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isEnabled={activeOptions[option.slug]}
-                                markForUpdate={() => markForUpdate(option.slug)}
+                                isChecked={activeOptions[option.slug] === true}
+                                toggle={() => activeOptions.toggle(option.slug)}
                             />
                         )
                     )
                 }
             </ul>
-            <footer>
-                <button onClick={modalControl.close}>Cancel</button>
-                <button onClick={clickConfirm}>Confirm</button>
-            </footer>
         </section>
     );
 }

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -82,8 +82,7 @@ export default function AppOptions(props: propsIF) {
     }
 
     function clickConfirm(): void {
-        // shouldToggleOnClose.current.forEach((elem: appOptions) => activeOptions.toggle(elem));
-        activeOptions.multiToggle(shouldToggleOnClose.current);
+        activeOptions.toggle(shouldToggleOnClose.current);
         modalControl.close();
     }
 
@@ -101,7 +100,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isEnabled={activeOptions[option.slug] === true}
+                                isEnabled={activeOptions[option.slug]}
                                 markForUpdate={() => markForUpdate(option.slug)}
                             />
                         )

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -117,6 +117,9 @@ export default function AppOptions(props: propsIF) {
                     )
                 }
             </ul>
+            <div className={styles.apply_defaults} onClick={activeOptions.applyDefaults}>
+                Apply Defaults
+            </div>
         </section>
     );
 }

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -82,7 +82,8 @@ export default function AppOptions(props: propsIF) {
     }
 
     function clickConfirm(): void {
-        shouldToggleOnClose.current.forEach((elem: appOptions) => activeOptions.toggle(elem));
+        // shouldToggleOnClose.current.forEach((elem: appOptions) => activeOptions.toggle(elem));
+        activeOptions.multiToggle(shouldToggleOnClose.current);
         modalControl.close();
     }
 

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,0 +1,10 @@
+import styles from './AppOptions.module.css';
+
+export default function AppOptions() {
+    return (
+        <section className={styles.app_options}>
+            <h2>App Options!</h2>
+            <p>This is the app options menu.</p>
+        </section>
+    );
+}

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
@@ -71,15 +70,6 @@ export default function AppOptions(props: propsIF) {
     const { modalControl } = props;
 
     const activeOptions: useAppOptionsIF = useAppOptions();
-
-    const shouldToggleOnClose = useRef<appOptions[]>([]);
-    function markForUpdate(o: appOptions): void {
-        let output: appOptions[];
-        shouldToggleOnClose.current.includes(o)
-            ? output = shouldToggleOnClose.current.filter((e) => e !== o)
-            : output = [...shouldToggleOnClose.current, o];
-        shouldToggleOnClose.current = output;
-    }
 
     return (
         <section className={styles.app_options}>

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -2,6 +2,7 @@ import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
 import { useAppOptions, type appOptions, type useAppOptionsIF } from '~/stores/AppOptionsStore';
+import { MdOutlineClose } from 'react-icons/md';
 
 export interface appOptionDataIF {
     slug: appOptions;
@@ -76,7 +77,11 @@ export default function AppOptions(props: propsIF) {
             <header>
                 <div />
                 <h2>Options</h2>
-                <button onClick={modalControl.close}>×</button>
+                <MdOutlineClose
+                    size={20}
+                    onClick={modalControl.close}
+                    style={{ cursor: 'pointer' }}
+                />
             </header>
             <ul>
                 {
@@ -92,7 +97,7 @@ export default function AppOptions(props: propsIF) {
                     )
                 }
             </ul>
-            <hr />
+            <div className={styles.horizontal_divider} />
             <ul>
                 {
                     optionsBottom.map(

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,7 +1,7 @@
 import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppOptions, type appOptions } from '~/stores/AppOptionsStore';
 
 export interface appOptionDataIF {
@@ -92,13 +92,24 @@ export default function AppOptions(props: propsIF) {
         return initialData;
     }
 
-    function clickConfirm(): void {
-        localStorage.setItem('APP_OPTIONS', JSON.stringify(checked));
-        modalControl.close();
-    }
-
     const activeOptions = useAppOptions();
     console.log(activeOptions);
+
+    const shouldToggleOnClose = useRef<appOptions[]>([]);
+    function markForUpdate(o: appOptions): void {
+        let output: appOptions[];
+        shouldToggleOnClose.current.includes(o)
+            ? output = shouldToggleOnClose.current.filter((e) => e !== o)
+            : output = [...shouldToggleOnClose.current, o];
+        shouldToggleOnClose.current = output;
+    }
+
+    function clickConfirm(): void {
+        // localStorage.setItem('APP_OPTIONS', JSON.stringify(checked));
+        console.log(shouldToggleOnClose.current);
+        shouldToggleOnClose.current.forEach((elem: appOptions) => activeOptions.toggle(elem));
+        modalControl.close();
+    }
 
     return (
         <section className={styles.app_options}>
@@ -114,8 +125,8 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isChecked={activeOptions[option.slug]}
-                                toggle={toggleChecked}
+                                isEnabled={activeOptions[option.slug] === true}
+                                markForUpdate={() => markForUpdate(option.slug)}
                             />
                         )
                     )
@@ -129,8 +140,8 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isChecked={activeOptions[option.slug]}
-                                toggle={toggleChecked}
+                                isEnabled={activeOptions[option.slug]}
+                                markForUpdate={() => markForUpdate(option.slug)}
                             />
                         )
                     )

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,8 +1,8 @@
+import { useRef } from 'react';
 import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
-import { useEffect, useRef, useState } from 'react';
-import { useAppOptions, type appOptions } from '~/stores/AppOptionsStore';
+import { useAppOptions, type appOptions, type useAppOptionsIF } from '~/stores/AppOptionsStore';
 
 export interface appOptionDataIF {
     slug: appOptions;
@@ -70,30 +70,7 @@ interface propsIF {
 export default function AppOptions(props: propsIF) {
     const { modalControl } = props;
 
-    const [checked, setChecked] = useState<string[]>(initializeData());
-    function toggleChecked(item: string) {
-        const updated: string[] = checked.includes(item)
-            ? checked.filter((c: string) => c !== item)
-            : [...checked, item];
-            console.log(updated);
-        setChecked(updated);
-    }
-
-    function initializeData(): string[] {
-        let initialData: string[];
-        const persisted: string|null = localStorage.getItem('APP_OPTIONS');
-        if (persisted) {
-            initialData = JSON.parse(persisted);
-        } else {
-            initialData = optionsTop.concat(optionsBottom)
-                .filter((opt: appOptionDataIF) => opt.isDefault)
-                .flatMap((opt: appOptionDataIF) => opt.slug);
-        }
-        return initialData;
-    }
-
-    const activeOptions = useAppOptions();
-    console.log(activeOptions);
+    const activeOptions: useAppOptionsIF = useAppOptions();
 
     const shouldToggleOnClose = useRef<appOptions[]>([]);
     function markForUpdate(o: appOptions): void {
@@ -105,8 +82,6 @@ export default function AppOptions(props: propsIF) {
     }
 
     function clickConfirm(): void {
-        // localStorage.setItem('APP_OPTIONS', JSON.stringify(checked));
-        console.log(shouldToggleOnClose.current);
         shouldToggleOnClose.current.forEach((elem: appOptions) => activeOptions.toggle(elem));
         modalControl.close();
     }

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,6 +1,53 @@
 import styles from './AppOptions.module.css';
 
+interface appOptionDataIF {
+    text: string;
+}
+
 export default function AppOptions() {
+
+    const optionsTop: appOptionDataIF[] = [
+        {
+            text: 'Skip Open Order Confirmations',
+        },
+        {
+            text: 'Skip Close Position Confirmations',
+        },
+        {
+            text: 'Opt Out of Spot Dusting',
+        },
+        {
+            text: 'Persist Trading Connection',
+        },
+    ];
+
+    const optionsBottom: appOptionDataIF[] = [
+        {
+            text: 'Display Verbose Errors',
+        },
+        {
+            text: 'Disable Background Fill Notifications',
+        },
+        {
+            text: 'Disable Playing Sound for Fills',
+        },
+        {
+            text: 'Animate Order Book',
+        },
+        {
+            text: 'Order Book Set Size on Click',
+        },
+        {
+            text: 'Show Buys and Sells on Chart',
+        },
+        {
+            text: 'Hide PnL',
+        },
+        {
+            text: 'Show All Warnings',
+        },
+    ];
+
     return (
         <section className={styles.app_options}>
             <header>
@@ -9,14 +56,23 @@ export default function AppOptions() {
                 <button>×</button>
             </header>
             <ul>
-                <li>First option here</li>
-                <li>Second option here</li>
-                <li>Third option here</li>
+                {
+                    optionsTop.map(
+                        (option: appOptionDataIF) => (
+                            <li key={JSON.stringify(option)}>{option.text}</li>
+                        )
+                    )
+                }
             </ul>
             <hr />
             <ul>
-                <li>Fourth option here</li>
-                <li>Fifth option here</li>
+                {
+                    optionsBottom.map(
+                        (option: appOptionDataIF) => (
+                            <li key={JSON.stringify(option)}>{option.text}</li>
+                        )
+                    )
+                }
             </ul>
             <footer>
                 <button>Cancel</button>

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -123,6 +123,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
+                                isChecked={checked.includes(option.slug)}
                                 toggle={toggleChecked}
                             />
                         )
@@ -137,6 +138,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
+                                isChecked={checked.includes(option.slug)}
                                 toggle={toggleChecked}
                             />
                         )

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -3,8 +3,25 @@ import styles from './AppOptions.module.css';
 export default function AppOptions() {
     return (
         <section className={styles.app_options}>
-            <h2>App Options!</h2>
-            <p>This is the app options menu.</p>
+            <header>
+                <div />
+                <h2>Options</h2>
+                <button>×</button>
+            </header>
+            <ul>
+                <li>First option here</li>
+                <li>Second option here</li>
+                <li>Third option here</li>
+            </ul>
+            <hr />
+            <ul>
+                <li>Fourth option here</li>
+                <li>Fifth option here</li>
+            </ul>
+            <footer>
+                <button>Cancel</button>
+                <button>Confirm</button>
+            </footer>
         </section>
     );
 }

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -2,33 +2,29 @@ import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
 import { useEffect, useState } from 'react';
+import { useAppOptions, type appOptions } from '~/stores/AppOptionsStore';
 
 export interface appOptionDataIF {
-    slug: string;
+    slug: appOptions;
     text: string;
-    isDefault: boolean;
 }
 
 const optionsTop: appOptionDataIF[] = [
     {
         slug: 'skipOpenOrderConfirm',
         text: 'Skip Open Order Confirmations',
-        isDefault: false,
     },
     {
         slug: 'skipClosePositionConfirm',
         text: 'Skip Close Position Confirmations',
-        isDefault: false,
     },
     {
-        slug: 'optOutOfSpotDusting',
+        slug: 'optOutSpotDusting',
         text: 'Opt Out of Spot Dusting',
-        isDefault: false,
     },
     {
         slug: 'persistTradingConnection',
         text: 'Persist Trading Connection',
-        isDefault: false,
     },
 ];
 
@@ -36,42 +32,34 @@ const optionsBottom: appOptionDataIF[] = [
     {
         slug: 'displayVerboseErrors',
         text: 'Display Verbose Errors',
-        isDefault: false,
     },
     {
-        slug: 'disableBackgroundFillNotif',
-        text: 'Disable Background Fill Notifications',
-        isDefault: false,
+        slug: 'enableBackgroundFillNotif',
+        text: 'Enable Background Fill Notifications',
     },
     {
-        slug: 'disableFillSound',
-        text: 'Disable Playing Sound for Fills',
-        isDefault: true,
+        slug: 'playFillSound',
+        text: 'Play Sound for Fills',
     },
     {
         slug: 'animateOrderBook',
         text: 'Animate Order Book',
-        isDefault: true,
     },
     {
-        slug: 'orderBookSetSizeOnClk',
+        slug: 'clickToSetOrderBookSize',
         text: 'Order Book Set Size on Click',
-        isDefault: true,
     },
     {
         slug: 'showBuysSellsOnChart',
         text: 'Show Buys and Sells on Chart',
-        isDefault: true,
     },
     {
-        slug: 'hidePnL',
-        text: 'Hide PnL',
-        isDefault: false,
+        slug: 'showPnL',
+        text: 'Show PnL',
     },
     {
         slug: 'showAllWarnings',
         text: 'Show All Warnings',
-        isDefault: true,
     },
 ];
 
@@ -109,6 +97,9 @@ export default function AppOptions(props: propsIF) {
         modalControl.close();
     }
 
+    const activeOptions = useAppOptions();
+    console.log(activeOptions);
+
     return (
         <section className={styles.app_options}>
             <header>
@@ -123,7 +114,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isChecked={checked.includes(option.slug)}
+                                isChecked={activeOptions[option.slug]}
                                 toggle={toggleChecked}
                             />
                         )
@@ -138,7 +129,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
-                                isChecked={checked.includes(option.slug)}
+                                isChecked={activeOptions[option.slug]}
                                 toggle={toggleChecked}
                             />
                         )

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,10 +1,16 @@
+import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 
 interface appOptionDataIF {
     text: string;
 }
 
-export default function AppOptions() {
+interface propsIF {
+    modalControl: useModalIF;
+}
+
+export default function AppOptions(props: propsIF) {
+    const { modalControl } = props;
 
     const optionsTop: appOptionDataIF[] = [
         {
@@ -53,7 +59,7 @@ export default function AppOptions() {
             <header>
                 <div />
                 <h2>Options</h2>
-                <button>×</button>
+                <button onClick={modalControl.close}>×</button>
             </header>
             <ul>
                 {
@@ -75,7 +81,7 @@ export default function AppOptions() {
                 }
             </ul>
             <footer>
-                <button>Cancel</button>
+                <button onClick={modalControl.close}>Cancel</button>
                 <button>Confirm</button>
             </footer>
         </section>

--- a/app/components/AppOptions/AppOptions.tsx
+++ b/app/components/AppOptions/AppOptions.tsx
@@ -1,7 +1,7 @@
 import type { useModalIF } from '~/hooks/useModal';
 import styles from './AppOptions.module.css';
 import OptionLine from './OptionLine';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface appOptionDataIF {
     slug: string;
@@ -15,7 +15,15 @@ interface propsIF {
 
 export default function AppOptions(props: propsIF) {
     const { modalControl } = props;
-    
+
+    const [checked, setChecked] = useState<string[]>([]);
+    function toggleChecked(item: string) {
+        const updated: string[] = checked.includes(item)
+            ? checked.filter((c: string) => c !== item)
+            : [...checked, item];
+            console.log(updated);
+        setChecked(updated);
+    }
 
     const optionsTop: appOptionDataIF[] = [
         {
@@ -97,6 +105,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
+                                toggle={toggleChecked}
                             />
                         )
                     )
@@ -110,6 +119,7 @@ export default function AppOptions(props: propsIF) {
                             <OptionLine
                                 key={JSON.stringify(option)}
                                 option={option}
+                                toggle={toggleChecked}
                             />
                         )
                     )

--- a/app/components/AppOptions/OptionLine.module.css
+++ b/app/components/AppOptions/OptionLine.module.css
@@ -1,3 +1,8 @@
 .option_line {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
     color: black;
 }

--- a/app/components/AppOptions/OptionLine.module.css
+++ b/app/components/AppOptions/OptionLine.module.css
@@ -4,6 +4,21 @@
     flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: center;
-    color: black;
+    /* padding: 2px 2px 2px 0px; */
+    gap: 8px;
+    width: fit-content;
+    color: var(--text1);
     cursor: pointer;
+    font-size: var(----font-size-s);
+}
+
+.checkbox {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border: 1px solid var(--text2);
+    border-radius: 4px;
 }

--- a/app/components/AppOptions/OptionLine.module.css
+++ b/app/components/AppOptions/OptionLine.module.css
@@ -5,4 +5,5 @@
     justify-content: flex-start;
     align-items: center;
     color: black;
+    cursor: pointer;
 }

--- a/app/components/AppOptions/OptionLine.module.css
+++ b/app/components/AppOptions/OptionLine.module.css
@@ -1,0 +1,3 @@
+.option_line {
+    color: black;
+}

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,27 +1,18 @@
-import { useState } from 'react';
 import styles from './OptionLIne.module.css';
 import type { appOptionDataIF } from './AppOptions';
 import { MdOutlineCheckBox, MdOutlineCheckBoxOutlineBlank } from 'react-icons/md';
 
 interface propsIF {
     option: appOptionDataIF;
-    isEnabled: boolean;
-    markForUpdate: () => void;
+    isChecked: boolean;
+    toggle: () => void;
 }
 
 export default function OptionLine(props: propsIF) {
-    const { option, isEnabled, markForUpdate } = props;
-
-    const [isChecked, setIsChecked] = useState<boolean>(isEnabled);
+    const { option, isChecked, toggle } = props;
 
     return (
-        <li
-            className={styles.option_line}
-            onClick={() => {
-                setIsChecked(!isChecked);
-                markForUpdate();
-            }}
-        >
+        <li className={styles.option_line} onClick={toggle}>
             { isChecked ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
             {option.text}
         </li>

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -5,15 +5,21 @@ import { useState } from 'react';
 
 interface propsIF {
     option: appOptionDataIF;
+    toggle: (item: string) => void;
 }
 
 export default function OptionLine(props: propsIF) {
-    const { option } = props;
+    const { option, toggle } = props;
 
     const [isOn, setIsOn] = useState<boolean>(option.isDefault);
 
+    function handleClick(): void {
+        setIsOn(!isOn);
+        toggle(option.slug);
+    }
+
     return (
-        <li className={styles.option_line} onClick={() => setIsOn(!isOn)}>
+        <li className={styles.option_line} onClick={() => handleClick()}>
             { isOn ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
             {option.text}
         </li>

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -10,7 +10,7 @@ interface propsIF {
 export default function OptionLine(props: propsIF) {
     const { option } = props;
 
-    const [isOn, setIsOn] = useState<boolean>(true);
+    const [isOn, setIsOn] = useState<boolean>(option.isDefault);
 
     return (
         <li className={styles.option_line} onClick={() => setIsOn(!isOn)}>

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,0 +1,16 @@
+import styles from './OptionLIne.module.css';
+import type { appOptionDataIF } from './AppOptions';
+
+interface propsIF {
+    option: appOptionDataIF;
+}
+
+export default function OptionLine(props: propsIF) {
+    const { option } = props;
+
+    return (
+        <li className={styles.option_line}>
+            {option.text}
+        </li>
+    );
+}

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,26 +1,19 @@
 import styles from './OptionLIne.module.css';
 import type { appOptionDataIF } from './AppOptions';
 import { MdOutlineCheckBox, MdOutlineCheckBoxOutlineBlank } from 'react-icons/md';
-import { useState } from 'react';
 
 interface propsIF {
     option: appOptionDataIF;
+    isChecked: boolean;
     toggle: (item: string) => void;
 }
 
 export default function OptionLine(props: propsIF) {
-    const { option, toggle } = props;
-
-    const [isOn, setIsOn] = useState<boolean>(option.isDefault);
-
-    function handleClick(): void {
-        setIsOn(!isOn);
-        toggle(option.slug);
-    }
+    const { option, isChecked, toggle } = props;
 
     return (
-        <li className={styles.option_line} onClick={() => handleClick()}>
-            { isOn ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
+        <li className={styles.option_line} onClick={() => toggle(option.slug)}>
+            { isChecked ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
             {option.text}
         </li>
     );

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,18 +1,27 @@
+import { useState } from 'react';
 import styles from './OptionLIne.module.css';
 import type { appOptionDataIF } from './AppOptions';
 import { MdOutlineCheckBox, MdOutlineCheckBoxOutlineBlank } from 'react-icons/md';
 
 interface propsIF {
     option: appOptionDataIF;
-    isChecked: boolean;
-    toggle: (item: string) => void;
+    isEnabled: boolean;
+    markForUpdate: () => void;
 }
 
 export default function OptionLine(props: propsIF) {
-    const { option, isChecked, toggle } = props;
+    const { option, isEnabled, markForUpdate } = props;
+
+    const [isChecked, setIsChecked] = useState<boolean>(isEnabled);
 
     return (
-        <li className={styles.option_line} onClick={() => toggle(option.slug)}>
+        <li
+            className={styles.option_line}
+            onClick={() => {
+                setIsChecked(!isChecked);
+                markForUpdate();
+            }}
+        >
             { isChecked ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
             {option.text}
         </li>

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,6 +1,6 @@
 import styles from './OptionLIne.module.css';
 import type { appOptionDataIF } from './AppOptions';
-import { MdOutlineCheckBox, MdOutlineCheckBoxOutlineBlank } from 'react-icons/md';
+import { FaCheck } from 'react-icons/fa';
 
 interface propsIF {
     option: appOptionDataIF;
@@ -13,7 +13,12 @@ export default function OptionLine(props: propsIF) {
 
     return (
         <li className={styles.option_line} onClick={toggle}>
-            { isChecked ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
+            <div
+                className={styles.checkbox}
+                style={{ borderColor: `var(${isChecked ? '--accent1' : '--text3'})` }}
+            >
+                {isChecked && <FaCheck size={10} color={'var(--accent1)'} />}
+            </div>
             {option.text}
         </li>
     );

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,6 +1,7 @@
 import styles from './OptionLIne.module.css';
 import type { appOptionDataIF } from './AppOptions';
 import { MdOutlineCheckBox, MdOutlineCheckBoxOutlineBlank } from 'react-icons/md';
+import { useState } from 'react';
 
 interface propsIF {
     option: appOptionDataIF;
@@ -9,10 +10,11 @@ interface propsIF {
 export default function OptionLine(props: propsIF) {
     const { option } = props;
 
+    const [isOn, setIsOn] = useState<boolean>(true);
+
     return (
-        <li className={styles.option_line}>
-            <MdOutlineCheckBoxOutlineBlank />
-            <MdOutlineCheckBox />
+        <li className={styles.option_line} onClick={() => setIsOn(!isOn)}>
+            { isOn ? <MdOutlineCheckBox /> : <MdOutlineCheckBoxOutlineBlank /> }
             {option.text}
         </li>
     );

--- a/app/components/AppOptions/OptionLine.tsx
+++ b/app/components/AppOptions/OptionLine.tsx
@@ -1,5 +1,6 @@
 import styles from './OptionLIne.module.css';
 import type { appOptionDataIF } from './AppOptions';
+import { MdOutlineCheckBox, MdOutlineCheckBoxOutlineBlank } from 'react-icons/md';
 
 interface propsIF {
     option: appOptionDataIF;
@@ -10,6 +11,8 @@ export default function OptionLine(props: propsIF) {
 
     return (
         <li className={styles.option_line}>
+            <MdOutlineCheckBoxOutlineBlank />
+            <MdOutlineCheckBox />
             {option.text}
         </li>
     );

--- a/app/components/Modal/Modal.module.css
+++ b/app/components/Modal/Modal.module.css
@@ -9,4 +9,5 @@
     justify-content: center;
     align-items: center;
     backdrop-filter: blur(10px);
+    z-index: 100000;
 }

--- a/app/components/PageHeader/PageHeader.tsx
+++ b/app/components/PageHeader/PageHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { LuMenu, LuWallet } from 'react-icons/lu';
+import { LuMenu, LuSettings, LuWallet } from 'react-icons/lu';
 import { MdOutlineClose, MdOutlineMoreHoriz } from 'react-icons/md';
 import { Link, useLocation } from 'react-router';
 import useOutsideClick from '~/hooks/useOutsideClick';
@@ -12,6 +12,9 @@ import DepositDropdown from './DepositDropdown/DepositDropdown';
 import NetworkDropdown from './NetworkDropdown/NetworkDropdown';
 import InternarionalSettingsDropdown from './InternarionalSettingsDropdown/InternarionalSettingsDropdown';
 import MoreDropdown from './MoreDropdown/MoreDropdown'
+import { type useModalIF, useModal } from '~/hooks/useModal';
+import AppOptions from '../AppOptions/AppOptions';
+import Modal from '../Modal/Modal';
 export default function PageHeader() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDropdownMenuOpen, setIsDropdownMenuOpen] = useState(false);
@@ -192,6 +195,9 @@ export default function PageHeader() {
       {isMoreDropdownOpen && <MoreDropdown/>}
     </section>
   );
+
+  const appSettingsModal: useModalIF = useModal('closed');
+
   return (
     <>
       <header className={styles.container}>
@@ -241,6 +247,13 @@ export default function PageHeader() {
           {internationalDropdownDisplay}
 
           <button
+            className={styles.internationalButton}
+            onClick={appSettingsModal.open}
+          >
+            <LuSettings size={20} />
+          </button>
+
+          <button
             className={styles.menuButton}
             onClick={() => setIsDropdownMenuOpen(!isDropdownMenuOpen)}
           >
@@ -264,6 +277,11 @@ export default function PageHeader() {
         >
           <DropdownMenu />
         </div>
+      )}
+      {appSettingsModal.isOpen && (
+          <Modal close={appSettingsModal.close}>
+              <AppOptions modalControl={appSettingsModal} />
+          </Modal>
       )}
     </>
   );

--- a/app/routes/testpage/testpage.tsx
+++ b/app/routes/testpage/testpage.tsx
@@ -1,7 +1,3 @@
-import AppOptions from "~/components/AppOptions/AppOptions";
-import Modal from "~/components/Modal/Modal";
-import { type useModalIF, useModal } from "~/hooks/useModal";
-
 interface propsIF {
 
 }
@@ -10,18 +6,8 @@ interface propsIF {
 export default function testpage(props: propsIF) {
     false && props;
 
-    const modalControl: useModalIF = useModal('closed');
-
     return (
         <div>
-            {/* interactable to open modal on user action */}
-            <button onClick={() => modalControl.open()}>Open Modal</button>
-            {/* format to insantiate modal in the DOM */}
-            {modalControl.isOpen && (
-                <Modal close={modalControl.close}>
-                    <AppOptions modalControl={modalControl} />
-                </Modal>
-            )}
         </div>
     );
 }

--- a/app/routes/testpage/testpage.tsx
+++ b/app/routes/testpage/testpage.tsx
@@ -19,7 +19,7 @@ export default function testpage(props: propsIF) {
             {/* format to insantiate modal in the DOM */}
             {modalControl.isOpen && (
                 <Modal close={modalControl.close}>
-                    <AppOptions />
+                    <AppOptions modalControl={modalControl} />
                 </Modal>
             )}
         </div>

--- a/app/routes/testpage/testpage.tsx
+++ b/app/routes/testpage/testpage.tsx
@@ -1,3 +1,4 @@
+import AppOptions from "~/components/AppOptions/AppOptions";
 import Modal from "~/components/Modal/Modal";
 import { type useModalIF, useModal } from "~/hooks/useModal";
 
@@ -18,17 +19,7 @@ export default function testpage(props: propsIF) {
             {/* format to insantiate modal in the DOM */}
             {modalControl.isOpen && (
                 <Modal close={modalControl.close}>
-                    <section
-                        style={{
-                            backgroundColor: 'orange',
-                            height: '500px',
-                            width: '300px',
-                            outline: '3px solid green',
-                        }}
-                    >
-                        <button onClick={modalControl.close}>Close</button>
-                        <h2>Options Menu!</h2>
-                    </section>
+                    <AppOptions />
                 </Modal>
             )}
         </div>

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -50,48 +50,9 @@ export const useAppOptions = create<useAppOptionsIF>()(
             showBuysSellsOnChart: true,
             showPnL: true,
             showAllWarnings: true,
-            enable: (o: appOptions) => {
-                o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: true});
-                o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: true});
-                o === 'optOutSpotDusting' && set({optOutSpotDusting: true});
-                o === 'persistTradingConnection' && set({persistTradingConnection: true});
-                o === 'displayVerboseErrors' && set({displayVerboseErrors: true});
-                o === 'enableBackgroundFillNotif' && set({enableBackgroundFillNotif: true});
-                o === 'playFillSound' && set({playFillSound: true});
-                o === 'animateOrderBook' && set({animateOrderBook: true});
-                o === 'clickToSetOrderBookSize' && set({clickToSetOrderBookSize: true});
-                o === 'showBuysSellsOnChart' && set({showBuysSellsOnChart: true});
-                o === 'showPnL' && set({showPnL: true});
-                o === 'showAllWarnings' && set({showAllWarnings: true});
-            },
-            disable: (o: appOptions) => {
-                o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: false});
-                o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: false});
-                o === 'optOutSpotDusting' && set({optOutSpotDusting: false});
-                o === 'persistTradingConnection' && set({persistTradingConnection: false});
-                o === 'displayVerboseErrors' && set({displayVerboseErrors: false});
-                o === 'enableBackgroundFillNotif' && set({enableBackgroundFillNotif: false});
-                o === 'playFillSound' && set({playFillSound: false});
-                o === 'animateOrderBook' && set({animateOrderBook: false});
-                o === 'clickToSetOrderBookSize' && set({clickToSetOrderBookSize: false});
-                o === 'showBuysSellsOnChart' && set({showBuysSellsOnChart: false});
-                o === 'showPnL' && set({showPnL: false});
-                o === 'showAllWarnings' && set({showAllWarnings: false});
-            },
-            toggle: (o: appOptions) => {
-                o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: !get()[o]});
-                o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: !get()[o]});
-                o === 'optOutSpotDusting' && set({optOutSpotDusting: !get()[o]});
-                o === 'persistTradingConnection' && set({persistTradingConnection: !get()[o]});
-                o === 'displayVerboseErrors' && set({displayVerboseErrors: !get()[o]});
-                o === 'enableBackgroundFillNotif' && set({enableBackgroundFillNotif: !get()[o]});
-                o === 'playFillSound' && set({playFillSound: !get()[o]});
-                o === 'animateOrderBook' && set({animateOrderBook: !get()[o]});
-                o === 'clickToSetOrderBookSize' && set({clickToSetOrderBookSize: !get()[o]});
-                o === 'showBuysSellsOnChart' && set({showBuysSellsOnChart: !get()[o]});
-                o === 'showPnL' && set({showPnL: !get()[o]});
-                o === 'showAllWarnings' && set({showAllWarnings: !get()[o]});
-            },
+            enable: (o: appOptions) => set({[o]: true}),
+            disable: (o: appOptions) => set({[o]: false}),
+            toggle: (o: appOptions) => set({[o]: !get()[o]}),
         }),
         {
             name: LS_KEY,

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 const DEFAULTS = {
     skipOpenOrderConfirm: false,

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -15,7 +15,7 @@ export type appOptions =
     | 'showPnL'
     | 'showAllWarnings';
 
-type useAppOptionsIF = {
+export interface useAppOptionsIF {
     skipOpenOrderConfirm: boolean;
     skipClosePositionConfirm: boolean;
     optOutSpotDusting: boolean;

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+type options = 
+    | 'skipOpenOrderConfirm'
+    | 'skipClosePositionConfirm'
+    | 'optOutSpotDusting'
+    | 'persistTradingConnection'
+    | 'displayVerboseErrors'
+    | 'enableBackgroundFillNotif'
+    | 'playFillSound'
+    | 'animateOrderBook'
+    | 'clickToSetOrderBookSize'
+    | 'showBuysSellsOnChart'
+    | 'showPnL'
+    | 'showAllWarnings';
+
+type useAppOptionsIF = {
+    skipOpenOrderConfirm: boolean;
+    skipClosePositionConfirm: boolean;
+    optOutSpotDusting: boolean;
+    persistTradingConnection: boolean;
+    displayVerboseErrors: boolean;
+    enableBackgroundFillNotif: boolean;
+    playFillSound: boolean;
+    animateOrderBook: boolean;
+    clickToSetOrderBookSize: boolean;
+    showBuysSellsOnChart: boolean;
+    showPnL: boolean;
+    showAllWarnings: boolean;
+    enable: (o: options) => void;
+    disable: (o: options) => void;
+    toggle: (o: options) => void;
+}
+
+const LS_KEY = 'APP_OPTIONS';
+
+export const useAppOptions = create<useAppOptionsIF>()(
+    persist(
+        (set, get) => ({
+            skipOpenOrderConfirm: false,
+            skipClosePositionConfirm: false,
+            optOutSpotDusting: false,
+            persistTradingConnection: false,
+            displayVerboseErrors: false,
+            enableBackgroundFillNotif: true,
+            playFillSound: false,
+            animateOrderBook: true,
+            clickToSetOrderBookSize: true,
+            showBuysSellsOnChart: true,
+            showPnL: true,
+            showAllWarnings: true,
+            enable: (o: options) => {
+                o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: true});
+                o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: true});
+                o === 'optOutSpotDusting' && set({optOutSpotDusting: true});
+                o === 'persistTradingConnection' && set({persistTradingConnection: true});
+                o === 'displayVerboseErrors' && set({displayVerboseErrors: true});
+                o === 'enableBackgroundFillNotif' && set({enableBackgroundFillNotif: true});
+                o === 'playFillSound' && set({playFillSound: true});
+                o === 'animateOrderBook' && set({animateOrderBook: true});
+                o === 'clickToSetOrderBookSize' && set({clickToSetOrderBookSize: true});
+                o === 'showBuysSellsOnChart' && set({showBuysSellsOnChart: true});
+                o === 'showPnL' && set({showPnL: true});
+                o === 'showAllWarnings' && set({showAllWarnings: true});
+            },
+            disable: (o: options) => {
+                o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: false});
+                o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: false});
+                o === 'optOutSpotDusting' && set({optOutSpotDusting: false});
+                o === 'persistTradingConnection' && set({persistTradingConnection: false});
+                o === 'displayVerboseErrors' && set({displayVerboseErrors: false});
+                o === 'enableBackgroundFillNotif' && set({enableBackgroundFillNotif: false});
+                o === 'playFillSound' && set({playFillSound: false});
+                o === 'animateOrderBook' && set({animateOrderBook: false});
+                o === 'clickToSetOrderBookSize' && set({clickToSetOrderBookSize: false});
+                o === 'showBuysSellsOnChart' && set({showBuysSellsOnChart: false});
+                o === 'showPnL' && set({showPnL: false});
+                o === 'showAllWarnings' && set({showAllWarnings: false});
+            },
+            toggle: (o: options) => {
+                o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: !get()[o]});
+                o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: !get()[o]});
+                o === 'optOutSpotDusting' && set({optOutSpotDusting: !get()[o]});
+                o === 'persistTradingConnection' && set({persistTradingConnection: !get()[o]});
+                o === 'displayVerboseErrors' && set({displayVerboseErrors: !get()[o]});
+                o === 'enableBackgroundFillNotif' && set({enableBackgroundFillNotif: !get()[o]});
+                o === 'playFillSound' && set({playFillSound: !get()[o]});
+                o === 'animateOrderBook' && set({animateOrderBook: !get()[o]});
+                o === 'clickToSetOrderBookSize' && set({clickToSetOrderBookSize: !get()[o]});
+                o === 'showBuysSellsOnChart' && set({showBuysSellsOnChart: !get()[o]});
+                o === 'showPnL' && set({showPnL: !get()[o]});
+                o === 'showAllWarnings' && set({showAllWarnings: !get()[o]});
+            },
+        }),
+        {
+            name: LS_KEY,
+            storage: createJSONStorage(() => localStorage),
+        },
+    ),
+)

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-type options = 
+export type appOptions = 
     | 'skipOpenOrderConfirm'
     | 'skipClosePositionConfirm'
     | 'optOutSpotDusting'
@@ -28,9 +28,9 @@ type useAppOptionsIF = {
     showBuysSellsOnChart: boolean;
     showPnL: boolean;
     showAllWarnings: boolean;
-    enable: (o: options) => void;
-    disable: (o: options) => void;
-    toggle: (o: options) => void;
+    enable: (o: appOptions) => void;
+    disable: (o: appOptions) => void;
+    toggle: (o: appOptions) => void;
 }
 
 const LS_KEY = 'APP_OPTIONS';
@@ -50,7 +50,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
             showBuysSellsOnChart: true,
             showPnL: true,
             showAllWarnings: true,
-            enable: (o: options) => {
+            enable: (o: appOptions) => {
                 o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: true});
                 o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: true});
                 o === 'optOutSpotDusting' && set({optOutSpotDusting: true});
@@ -64,7 +64,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
                 o === 'showPnL' && set({showPnL: true});
                 o === 'showAllWarnings' && set({showAllWarnings: true});
             },
-            disable: (o: options) => {
+            disable: (o: appOptions) => {
                 o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: false});
                 o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: false});
                 o === 'optOutSpotDusting' && set({optOutSpotDusting: false});
@@ -78,7 +78,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
                 o === 'showPnL' && set({showPnL: false});
                 o === 'showAllWarnings' && set({showAllWarnings: false});
             },
-            toggle: (o: options) => {
+            toggle: (o: appOptions) => {
                 o === 'skipOpenOrderConfirm' && set({skipOpenOrderConfirm: !get()[o]});
                 o === 'skipClosePositionConfirm' && set({skipClosePositionConfirm: !get()[o]});
                 o === 'optOutSpotDusting' && set({optOutSpotDusting: !get()[o]});

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
+// default values for the state values managed by this hook
 const DEFAULTS = {
     skipOpenOrderConfirm: false,
     skipClosePositionConfirm: false,
@@ -16,8 +17,10 @@ const DEFAULTS = {
     showAllWarnings: true,
 }
 
+// string-union type of all keys in the `DEFAULTS` obj
 export type appOptions = keyof typeof DEFAULTS;
 
+// extended interface describing the shape of `DEFAULTS` and reducers
 export interface useAppOptionsIF extends Record<appOptions, boolean> {
     enable: (o: appOptions) => void;
     disable: (o: appOptions) => void;
@@ -25,19 +28,29 @@ export interface useAppOptionsIF extends Record<appOptions, boolean> {
     applyDefaults: () => void;
 }
 
+// key to identify data obj in local storage
 const LS_KEY = 'APP_OPTIONS';
 
+// hook to manage global state and local storage
 export const useAppOptions = create<useAppOptionsIF>()(
+    // persist data in local storage (only values, not reducers)
     persist(
         (set, get) => ({
+            // consume data from the `DEFAULT` obj, persisted data from
+            // ... local storage will re-hydrate if present
             ...DEFAULTS,
+            // set a given option to `true`
             enable: (o: appOptions): void => set({[o]: true}),
+            // set a given option to `false`
             disable: (o: appOptions): void => set({[o]: false}),
+            // toggle a value `true` ⟷ `false`
             toggle: (o: appOptions): void => set({[o]: !get()[o]}),
             applyDefaults: (): void => set(DEFAULTS),
         }),
         {
+            // key for local storage
             name: LS_KEY,
+            // format and destination of data
             storage: createJSONStorage(() => localStorage),
         },
     ),

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -21,7 +21,7 @@ export type appOptions = keyof typeof DEFAULTS;
 export interface useAppOptionsIF extends Record<appOptions, boolean> {
     enable: (o: appOptions) => void;
     disable: (o: appOptions) => void;
-    toggle: (o: appOptions|appOptions[]) => void;
+    toggle: (o: appOptions) => void;
     applyDefaults: () => void;
 }
 
@@ -33,16 +33,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
             ...DEFAULTS,
             enable: (o: appOptions): void => set({[o]: true}),
             disable: (o: appOptions): void => set({[o]: false}),
-            toggle: (o: appOptions|appOptions[]): void => {
-                if (typeof o === 'string') {
-                    set({[o]: !get()[o]});
-                }
-                if (Array.isArray(o)) {
-                    const changes: Partial<Record<appOptions, boolean>> = {};
-                    o.forEach((opt: appOptions) => changes[opt] = !get()[opt]);
-                    set(changes);
-                }
-            },
+            toggle: (o: appOptions): void => set({[o]: !get()[o]}),
             applyDefaults: (): void => set(DEFAULTS),
         }),
         {

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -63,7 +63,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
                 if (Array.isArray(o)) {
                     const changes: Partial<Record<appOptions, boolean>> = {};
                     o.forEach((opt: appOptions) => changes[opt] = !get()[opt]);
-                    set({...changes});
+                    set(changes);
                 }
             },
         }),

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -35,21 +35,25 @@ export interface useAppOptionsIF {
 
 const LS_KEY = 'APP_OPTIONS';
 
+const DEFAULTS: Record<appOptions, boolean> = {
+    skipOpenOrderConfirm: false,
+    skipClosePositionConfirm: false,
+    optOutSpotDusting: false,
+    persistTradingConnection: false,
+    displayVerboseErrors: false,
+    enableBackgroundFillNotif: true,
+    playFillSound: false,
+    animateOrderBook: true,
+    clickToSetOrderBookSize: true,
+    showBuysSellsOnChart: true,
+    showPnL: true,
+    showAllWarnings: true,
+}
+
 export const useAppOptions = create<useAppOptionsIF>()(
     persist(
         (set, get) => ({
-            skipOpenOrderConfirm: false,
-            skipClosePositionConfirm: false,
-            optOutSpotDusting: false,
-            persistTradingConnection: false,
-            displayVerboseErrors: false,
-            enableBackgroundFillNotif: true,
-            playFillSound: false,
-            animateOrderBook: true,
-            clickToSetOrderBookSize: true,
-            showBuysSellsOnChart: true,
-            showPnL: true,
-            showAllWarnings: true,
+            ...DEFAULTS,
             enable: (o: appOptions): void => set({[o]: true}),
             disable: (o: appOptions): void => set({[o]: false}),
             toggle: (o: appOptions|appOptions[]): void => {
@@ -61,7 +65,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
                     o.forEach((opt: appOptions) => changes[opt] = !get()[opt]);
                     set({...changes});
                 }
-            }
+            },
         }),
         {
             name: LS_KEY,

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -31,6 +31,7 @@ export interface useAppOptionsIF {
     enable: (o: appOptions) => void;
     disable: (o: appOptions) => void;
     toggle: (o: appOptions|appOptions[]) => void;
+    applyDefaults: () => void;
 }
 
 const LS_KEY = 'APP_OPTIONS';
@@ -66,6 +67,7 @@ export const useAppOptions = create<useAppOptionsIF>()(
                     set(changes);
                 }
             },
+            applyDefaults: (): void => set(DEFAULTS),
         }),
         {
             name: LS_KEY,

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -51,14 +51,14 @@ export const useAppOptions = create<useAppOptionsIF>()(
             showBuysSellsOnChart: true,
             showPnL: true,
             showAllWarnings: true,
-            enable: (o: appOptions) => set({[o]: true}),
-            disable: (o: appOptions) => set({[o]: false}),
-            toggle: (o: appOptions) => {
+            enable: (o: appOptions): void => set({[o]: true}),
+            disable: (o: appOptions): void => set({[o]: false}),
+            toggle: (o: appOptions): void => {
                 console.log('updating: ' + o);
                 console.log(typeof o);
                 set({[o]: !get()[o]});
             },
-            multiToggle: (o: appOptions[]) => {
+            multiToggle: (o: appOptions[]): void => {
                 console.log('multi-toggle!');
                 const changes: Partial<Record<appOptions, boolean>> = {};
                 o.forEach((opt: appOptions) => changes[opt] = !get()[opt])

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -31,6 +31,7 @@ export interface useAppOptionsIF {
     enable: (o: appOptions) => void;
     disable: (o: appOptions) => void;
     toggle: (o: appOptions) => void;
+    multiToggle: (o: appOptions[]) => void;
 }
 
 const LS_KEY = 'APP_OPTIONS';
@@ -52,7 +53,17 @@ export const useAppOptions = create<useAppOptionsIF>()(
             showAllWarnings: true,
             enable: (o: appOptions) => set({[o]: true}),
             disable: (o: appOptions) => set({[o]: false}),
-            toggle: (o: appOptions) => set({[o]: !get()[o]}),
+            toggle: (o: appOptions) => {
+                console.log('updating: ' + o);
+                console.log(typeof o);
+                set({[o]: !get()[o]});
+            },
+            multiToggle: (o: appOptions[]) => {
+                console.log('multi-toggle!');
+                const changes: Partial<Record<appOptions, boolean>> = {};
+                o.forEach((opt: appOptions) => changes[opt] = !get()[opt])
+                set({...changes});
+            }
         }),
         {
             name: LS_KEY,

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -1,42 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-export type appOptions = 
-    | 'skipOpenOrderConfirm'
-    | 'skipClosePositionConfirm'
-    | 'optOutSpotDusting'
-    | 'persistTradingConnection'
-    | 'displayVerboseErrors'
-    | 'enableBackgroundFillNotif'
-    | 'playFillSound'
-    | 'animateOrderBook'
-    | 'clickToSetOrderBookSize'
-    | 'showBuysSellsOnChart'
-    | 'showPnL'
-    | 'showAllWarnings';
-
-export interface useAppOptionsIF {
-    skipOpenOrderConfirm: boolean;
-    skipClosePositionConfirm: boolean;
-    optOutSpotDusting: boolean;
-    persistTradingConnection: boolean;
-    displayVerboseErrors: boolean;
-    enableBackgroundFillNotif: boolean;
-    playFillSound: boolean;
-    animateOrderBook: boolean;
-    clickToSetOrderBookSize: boolean;
-    showBuysSellsOnChart: boolean;
-    showPnL: boolean;
-    showAllWarnings: boolean;
-    enable: (o: appOptions) => void;
-    disable: (o: appOptions) => void;
-    toggle: (o: appOptions|appOptions[]) => void;
-    applyDefaults: () => void;
-}
-
-const LS_KEY = 'APP_OPTIONS';
-
-const DEFAULTS: Record<appOptions, boolean> = {
+const DEFAULTS = {
     skipOpenOrderConfirm: false,
     skipClosePositionConfirm: false,
     optOutSpotDusting: false,
@@ -50,6 +15,17 @@ const DEFAULTS: Record<appOptions, boolean> = {
     showPnL: true,
     showAllWarnings: true,
 }
+
+export type appOptions = keyof typeof DEFAULTS;
+
+export interface useAppOptionsIF extends Record<appOptions, boolean> {
+    enable: (o: appOptions) => void;
+    disable: (o: appOptions) => void;
+    toggle: (o: appOptions|appOptions[]) => void;
+    applyDefaults: () => void;
+}
+
+const LS_KEY = 'APP_OPTIONS';
 
 export const useAppOptions = create<useAppOptionsIF>()(
     persist(

--- a/app/stores/AppOptionsStore.ts
+++ b/app/stores/AppOptionsStore.ts
@@ -30,8 +30,7 @@ export interface useAppOptionsIF {
     showAllWarnings: boolean;
     enable: (o: appOptions) => void;
     disable: (o: appOptions) => void;
-    toggle: (o: appOptions) => void;
-    multiToggle: (o: appOptions[]) => void;
+    toggle: (o: appOptions|appOptions[]) => void;
 }
 
 const LS_KEY = 'APP_OPTIONS';
@@ -53,16 +52,15 @@ export const useAppOptions = create<useAppOptionsIF>()(
             showAllWarnings: true,
             enable: (o: appOptions): void => set({[o]: true}),
             disable: (o: appOptions): void => set({[o]: false}),
-            toggle: (o: appOptions): void => {
-                console.log('updating: ' + o);
-                console.log(typeof o);
-                set({[o]: !get()[o]});
-            },
-            multiToggle: (o: appOptions[]): void => {
-                console.log('multi-toggle!');
-                const changes: Partial<Record<appOptions, boolean>> = {};
-                o.forEach((opt: appOptions) => changes[opt] = !get()[opt])
-                set({...changes});
+            toggle: (o: appOptions|appOptions[]): void => {
+                if (typeof o === 'string') {
+                    set({[o]: !get()[o]});
+                }
+                if (Array.isArray(o)) {
+                    const changes: Partial<Record<appOptions, boolean>> = {};
+                    o.forEach((opt: appOptions) => changes[opt] = !get()[opt]);
+                    set({...changes});
+                }
             }
         }),
         {

--- a/app/stores/AppSettingsStore.ts
+++ b/app/stores/AppSettingsStore.ts
@@ -1,6 +1,5 @@
 import {create} from 'zustand';
 import { buySellColors, Langs, NumFormatTypes, type BuySellColor, type LangType, type NumFormat } from '~/utils/Constants';
-import type { OrderBookTradeIF, OrderRowIF } from '~/utils/orderbook/OrderBookIFs';
 
 interface AppSettingsStore {
     orderBookMode: 'tab' | 'stacked' | 'large';


### PR DESCRIPTION
## Features
* Create an app options store with zustand
* Sync store to local storage with zustand `persist()` method
* Create a modal workflow to toggle app options
* Add an icon to the page header to launch the options modal

## Testing
* Click the gear icon in the page header from different pages to launch the modal
* Click `Reset Defaults` and observe whether options are correctly reset
* Open dev tools to see that all persisted values are updated in local storage when toggled in the DOM
* Check that the options modal always opens with the same options checked as when last dismissed
* Check that the options modal dismisses on outside click, close button click, and <kbd>Esc</kbd> keypress
* Make sure that styling and verbiage consistent with the Figma diagram