### PR TITLE
Fix new line problem on SymbolInfo and WatchList components

### DIFF
--- a/app/routes/trade/symbol/symbolinfo.module.css
+++ b/app/routes/trade/symbol/symbolinfo.module.css
@@ -17,6 +17,5 @@
 
 .symbolInfoFieldsWrapper {
     display: inline-block;
-    /* white-space: nowrap;
-    overflow: hidden; */
+    white-space: nowrap;
 }

--- a/app/routes/trade/watchlist/watchlist.module.css
+++ b/app/routes/trade/watchlist/watchlist.module.css
@@ -34,4 +34,5 @@
     gap: 1rem;
     align-items: center;
     justify-content: center;
+    white-space: nowrap;
 }


### PR DESCRIPTION
Whitespace rules have been defined for both wrapper components to prevent them adding children into new lines