### PR TITLE
fixed : multiple volume display when switching pages

### DIFF
--- a/app/contexts/TradingviewContext.tsx
+++ b/app/contexts/TradingviewContext.tsx
@@ -2,6 +2,7 @@ import {
     widget,
     type IChartingLibraryWidget,
     type ResolutionString,
+    type TradingTerminalFeatureset,
 } from '~/tv/charting_library';
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { createDataFeed } from '~/routes/chart/data/customDataFeed';
@@ -81,11 +82,16 @@ export const TradingViewProvider: React.FC<{ children: React.ReactNode }> = ({
             fullscreen: false,
             autosize: true,
             datafeed: createDataFeed(subscribe) as any,
-            interval: (chartState?.interval || "1D") as ResolutionString,
+            interval: (chartState?.interval || '1D') as ResolutionString,
             disabled_features: [
                 'volume_force_overlay',
                 'header_symbol_search',
                 'header_compare',
+                ...(chartState
+                    ? [
+                          'create_volume_indicator_by_default' as TradingTerminalFeatureset,
+                      ]
+                    : []),
             ],
             favorites: {
                 intervals: ['5', '1h', 'D'] as ResolutionString[],


### PR DESCRIPTION
**Steps to reproduce the bug**

1. open the chart
2. Update any property stored in local storage (add new indicator, switch interval etc.)
3. open another page
4. return to the trade page

**Fix Details**

- default volume indicator is no longer added if a saved instance exists in local storage