### PR TITLE
Open Orders Live Update, Order History Table Fetch & Live Update, WS Pause Btn

### DIFF
--- a/app/components/Notifications/Notifications.tsx
+++ b/app/components/Notifications/Notifications.tsx
@@ -10,7 +10,7 @@ import {
 import { useKeydown } from '~/hooks/useKeydown';
 import { useDebugStore } from '~/stores/DebugStore';
 import { useEffect, useRef } from 'react';
-import { useWsObserver } from '~/hooks/useWsObserver';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
 
 export default function Notifications() {
 
@@ -36,7 +36,7 @@ export default function Notifications() {
     // use effect to subscribe to notifications
     useEffect(() => {
         if(debugWallet.address){
-            subscribe('notification', {
+            subscribe(WsChannels.NOTIFICATION, {
                 payload: {
                     user: debugWallet.address
                 },

--- a/app/components/Trade/OpenOrdersTable/OpenOrdersTable.tsx
+++ b/app/components/Trade/OpenOrdersTable/OpenOrdersTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import OpenOrdersTableHeader from './OpenOrdersTableHeader';
 import OpenOrdersTableRow, { type OpenOrderData } from './OpenOrdersTableRow';
 import styles from './OpenOrdersTable.module.css';
@@ -8,10 +8,11 @@ import { useTradeDataStore } from '~/stores/TradeDataStore';
 interface OpenOrdersTableProps {
   onCancel?: (time: number, coin: string) => void;
   onViewAll?: () => void;
+  selectedFilter: string;
 }
 
 export default function OpenOrdersTable(props: OpenOrdersTableProps) {
-  const { onCancel, onViewAll } = props;
+  const { onCancel, onViewAll, selectedFilter } = props;
   
   const handleCancel = (time: number, coin: string) => {
     if (onCancel) {
@@ -25,13 +26,28 @@ export default function OpenOrdersTable(props: OpenOrdersTableProps) {
     }
   };
 
-  const { userSymbolOrders } = useTradeDataStore();
+  const { userSymbolOrders, userOrders } = useTradeDataStore();
+
+  const filteredOrders = useMemo(() => {
+    switch(selectedFilter){
+      case 'all':
+        return userOrders;
+      case 'active':
+        return userSymbolOrders;
+      case 'long':
+        return userOrders.filter((order) => order.side === 'buy');
+      case 'short':
+        return userOrders.filter((order) => order.side === 'sell');
+    }
+
+    return userOrders;
+  }, [userOrders, selectedFilter]);
   
   return (
     <div className={styles.tableWrapper}>
       <OpenOrdersTableHeader />
       <div className={styles.tableBody}>
-        {userSymbolOrders.map((order, index) => (
+        {filteredOrders.slice(0, 50).map((order, index) => (
           <OpenOrdersTableRow 
             key={`order-${index}`} 
             order={order} 

--- a/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
+++ b/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import OrderHistoryTableHeader from './OrderHistoryTableHeader';
-import OrderHistoryTableRow, { type OrderHistoryData } from './OrderHistoryTableRow';
+import { useTradeDataStore } from '~/stores/TradeDataStore';
 import styles from './OrderHistoryTable.module.css';
+import OrderHistoryTableHeader from './OrderHistoryTableHeader';
+import OrderHistoryTableRow from './OrderHistoryTableRow';
 import { orderHistoryData } from './data';
 
 interface OrderHistoryTableProps {
@@ -10,6 +11,8 @@ interface OrderHistoryTableProps {
 
 export default function OrderHistoryTable(props: OrderHistoryTableProps) {
   const { onViewAll } = props;
+
+  const { orderHistory } = useTradeDataStore();
 
   const handleViewAll = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -22,7 +25,7 @@ export default function OrderHistoryTable(props: OrderHistoryTableProps) {
     <div className={styles.tableWrapper}>
       <OrderHistoryTableHeader />
       <div className={styles.tableBody}>
-        {orderHistoryData.map((order, index) => (
+        {orderHistory.map((order, index) => (
           <OrderHistoryTableRow 
             key={`order-${index}`} 
             order={order}

--- a/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
+++ b/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
@@ -1,18 +1,87 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useTradeDataStore } from '~/stores/TradeDataStore';
 import styles from './OrderHistoryTable.module.css';
 import OrderHistoryTableHeader from './OrderHistoryTableHeader';
 import OrderHistoryTableRow from './OrderHistoryTableRow';
 import { orderHistoryData } from './data';
+import { useWsObserver } from '~/hooks/useWsObserver';
+import { useDebugStore } from '~/stores/DebugStore';
+import type { OrderDataIF } from '~/utils/orderbook/OrderBookIFs';
+import { processUserOrder } from '~/processors/processOrderBook';
+import type { FilterOption } from '../TradeTables/TradeTables';
 
 interface OrderHistoryTableProps {
   onViewAll?: () => void;
+  selectedFilter: string;
 }
 
 export default function OrderHistoryTable(props: OrderHistoryTableProps) {
-  const { onViewAll } = props;
+  const { onViewAll, selectedFilter } = props;
 
   const { orderHistory } = useTradeDataStore();
+
+  const {subscribe, unsubscribeAllByChannel} = useWsObserver();
+  const {addOrderToHistory, symbol, setOrderHistory} = useTradeDataStore();
+
+  const userOrderHistoryRef = useRef<OrderDataIF[]>([]);
+
+  const {debugWallet} = useDebugStore();
+
+  const filterOrderHistory = useCallback((orderHistory: OrderDataIF[]) => {
+    switch(selectedFilter){
+      case 'all':
+        return orderHistory;
+      case 'active':
+        return orderHistory.filter((order) => order.coin === symbol);
+      case 'long':
+        return orderHistory.filter((order) => order.side === 'buy');
+      case 'short':
+        return orderHistory.filter((order) => order.side === 'sell');
+    }
+    return orderHistory;
+  }, [selectedFilter, symbol]);
+
+  
+  useEffect(() => {
+
+    const saveIntoStoreInterval = setInterval(() => {
+      addOrderToHistory(filterOrderHistory(userOrderHistoryRef.current));
+    }, 1000);
+
+    return () => {
+      clearInterval(saveIntoStoreInterval);
+    }
+    
+  }, [filterOrderHistory]);
+
+  useEffect(() => {
+    userOrderHistoryRef.current = filterOrderHistory(orderHistory).slice(0, 50);
+    setOrderHistory(userOrderHistoryRef.current);
+  }, [selectedFilter, symbol]);
+
+  useEffect(() => {
+    subscribe('userHistoricalOrders', {
+      payload: { user: debugWallet.address },
+      handler: (payload) => {
+        
+        if(payload && payload.orderHistory && payload.orderHistory.length > 0){
+          const orderUpdates: OrderDataIF[] = [];
+          payload.orderHistory.map((o:any) => {
+            const processedOrder = processUserOrder(o.order, o.status);
+            if(processedOrder){
+              orderUpdates.push(processedOrder);
+            }
+          })
+          userOrderHistoryRef.current = filterOrderHistory([...orderUpdates, ...userOrderHistoryRef.current]).slice(0, 50);
+          userOrderHistoryRef.current.sort((a, b) => b.timestamp - a.timestamp);
+        }
+      }
+    });
+
+    return () => {
+      unsubscribeAllByChannel('userHistoricalOrders');
+    }
+  }, [debugWallet.address]);
 
   const handleViewAll = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/app/components/Trade/OrderHistoryTable/OrderHistoryTableRow.tsx
+++ b/app/components/Trade/OrderHistoryTable/OrderHistoryTableRow.tsx
@@ -1,45 +1,43 @@
+import { useAppSettings } from '~/stores/AppSettingsStore';
 import styles from './OrderHistoryTable.module.css';
-
-export interface OrderHistoryData {
-  time: string;
-  type: string;
-  coin: string;
-  direction: 'Long' | 'Short';
-  size: string;
-  filledSize: string;
-  orderValue: string;
-  price: string;
-  reduceOnly: string;
-  triggerConditions: string;
-  tpsl: string;
-  status: string;
-  orderId: string;
-}
-
+import type { OrderDataIF } from '~/utils/orderbook/OrderBookIFs';
+import { formatTimestamp } from '~/utils/orderbook/OrderBookUtils';
+import useNumFormatter from '~/hooks/useNumFormatter';
 interface OrderHistoryTableRowProps {
-  order: OrderHistoryData;
+  order: OrderDataIF;
 }
 
 export default function OrderHistoryTableRow(props: OrderHistoryTableRowProps) {
   const { order } = props;
 
+  const {formatNum} = useNumFormatter();
+  const {isInverseColor} = useAppSettings();
+
+  const getDirectionClass = (side: string) => {
+    if(side === 'buy' && !isInverseColor) return styles.longDirection;
+    if(side === 'buy' && isInverseColor) return styles.shortDirection;
+    if(side === 'sell' && !isInverseColor) return styles.shortDirection;
+    if(side === 'sell' && isInverseColor) return styles.longDirection;
+  }
+
+
   return (
     <div className={styles.rowContainer}>
-      <div className={`${styles.cell} ${styles.timeCell}`}>{order.time}</div>
-      <div className={`${styles.cell} ${styles.typeCell}`}>{order.type}</div>
+      <div className={`${styles.cell} ${styles.timeCell}`}>{formatTimestamp(order.timestamp)}</div>
+      <div className={`${styles.cell} ${styles.typeCell}`}>{order.orderType}</div>
       <div className={`${styles.cell} ${styles.coinCell}`}>{order.coin}</div>
-      <div className={`${styles.cell} ${styles.directionCell} ${order.direction === 'Long' ? styles.longDirection : styles.shortDirection}`}>
-        {order.direction}
+      <div className={`${styles.cell} ${styles.directionCell} ${getDirectionClass(order.side)}`}>
+        {order.side === 'buy' ? 'Long' : 'Short'}
       </div>
-      <div className={`${styles.cell} ${styles.sizeCell}`}>{order.size}</div>
-      <div className={`${styles.cell} ${styles.filledSizeCell}`}>{order.filledSize}</div>
-      <div className={`${styles.cell} ${styles.orderValueCell}`}>{order.orderValue}</div>
-      <div className={`${styles.cell} ${styles.priceCell}`}>{order.price}</div>
+      <div className={`${styles.cell} ${styles.sizeCell}`}>{order.sz ? formatNum(order.sz) : '--'}</div>
+      <div className={`${styles.cell} ${styles.filledSizeCell}`}>{order.filledSz ? formatNum(order.filledSz) : '--'}</div>
+      <div className={`${styles.cell} ${styles.orderValueCell}`}>{order.sz ? formatNum(order.sz * order.limitPx) : '--'}</div>
+      <div className={`${styles.cell} ${styles.priceCell}`}>{order.limitPx ? formatNum(order.limitPx) : '--'}</div>
       <div className={`${styles.cell} ${styles.reduceOnlyCell}`}>{order.reduceOnly}</div>
-      <div className={`${styles.cell} ${styles.triggerConditionsCell}`}>{order.triggerConditions}</div>
-      <div className={`${styles.cell} ${styles.tpslCell}`}>{order.tpsl}</div>
+      <div className={`${styles.cell} ${styles.triggerConditionsCell}`}>{order.triggerCondition}</div>
+      <div className={`${styles.cell} ${styles.tpslCell}`}>{order.isTrigger ? formatNum(order.triggerPx || 0) : '--'}</div>
       <div className={`${styles.cell} ${styles.statusCell}`}>{order.status}</div>
-      <div className={`${styles.cell} ${styles.orderIdCell}`}>{order.orderId}</div>
+      <div className={`${styles.cell} ${styles.orderIdCell}`}>{order.oid}</div>
     </div>
   );
 }

--- a/app/components/Trade/TradeTables/TradeTables.tsx
+++ b/app/components/Trade/TradeTables/TradeTables.tsx
@@ -84,11 +84,10 @@ export default function TradeTable(props: TradeTableProps) {
         switch (activeTab) {
             case 'Balances':
                 return <BalancesTable />;
-
             case 'Positions':
                 return <PositionsTable />;
             case 'Open Orders':
-                return <OpenOrdersTable />;
+                return <OpenOrdersTable selectedFilter={selectedFilter} />;
             case 'TWAP':
                 return <TwapTable />;
             case 'Trade History':
@@ -96,7 +95,7 @@ export default function TradeTable(props: TradeTableProps) {
             case 'Funding History':
                 return <FundingHistoryTable />;
             case 'Order History':
-                return <OrderHistoryTable />;
+                return <OrderHistoryTable selectedFilter={selectedFilter} />;
             case 'Deposits and Withdrawals':
                 return <DepositsWithdrawalsTable />;
             default:

--- a/app/hooks/useInfoApi.ts
+++ b/app/hooks/useInfoApi.ts
@@ -10,12 +10,19 @@ export type ApiCallConfig = {
   payload?: any;
 }
 
-const apiUrl = 'https://api-ui.hyperliquid.xyz/info';
+
+export enum ApiEndpoints {
+  HISTORICAL_ORDERS = 'historicalOrders',
+  OPEN_ORDERS = 'frontendOpenOrders',
+}
+
+// const apiUrl = 'https://api-ui.hyperliquid.xyz/info';
+const apiUrl = 'https://api.hyperliquid.xyz/info';
 
 
 export function useInfoApi() {
 
-  const fetchInfo = async (config: ApiCallConfig) => {
+  const fetchData = async (config: ApiCallConfig) => {
     const response = await fetch(apiUrl, {
       method: 'POST',
       headers: { "Content-Type": "application/json" },
@@ -24,6 +31,7 @@ export function useInfoApi() {
     const data = await response.json();
     config.handler(data);
   }
+  
 
-  return { fetchInfo};
+  return { fetchData};
 }

--- a/app/hooks/useWsObserver.ts
+++ b/app/hooks/useWsObserver.ts
@@ -11,6 +11,18 @@ export type WsSubscriptionConfig = {
 }
 
 
+export enum WsChannels {
+  ORDERBOOK = 'l2Book',
+  ORDERBOOK_TRADES = 'trades',
+  USER_FILLS = 'userFills',
+  USER_HISTORICAL_ORDERS = 'userHistoricalOrders',
+  COINS = 'webData2',
+  ACTIVE_COIN_DATA = 'activeAssetCtx',
+  NOTIFICATION = 'notification',
+  CANDLE = 'candle',
+}
+
+
 export function useWsObserver() {
   
 

--- a/app/processors/processOrderBook.ts
+++ b/app/processors/processOrderBook.ts
@@ -65,26 +65,28 @@ export function processOrderBookTrades(data: any): OrderBookTradeIF[] {
 }
 
 
-export function processUserOrders(data: any, status: string): OrderDataIF[] {
-  return data.map((e: any) => {
+export function processUserOrder(data: any, status: string): OrderDataIF|null {
+  if (data) {
     return {
-      coin: e.coin,
-      cloid: e.cloid,
-      oid: parseNum(e.oid),
+      coin: data.coin,
+      cloid: data.cloid,
+      oid: parseNum(data.oid),
       // side: e.side,
-      side: e.side === 'A' ? 'sell' : 'buy',
-      sz: parseNum(e.sz),
-      tif: e.tif,
-      timestamp: e.timestamp,
+      side: data.side === 'A' ? 'sell' : 'buy',
+      sz: parseNum(data.sz),
+      tif: data.tif,
+      timestamp: data.timestamp,
       status: status,
-      limitPx: parseNum(e.limitPx),
-      origSz: parseNum(e.origSz),
-      reduceOnly: e.reduceOnly,
-      isPositionTpsl: e.isPositionTpsl,
-      isTrigger: e.isTrigger,
-      triggerPx: parseNum(e.triggerPx),
-      triggerCondition: e.triggerCondition,
-      orderType: e.orderType
+      limitPx: parseNum(data.limitPx),
+      origSz: parseNum(data.origSz),
+      reduceOnly: data.reduceOnly,
+      isPositionTpsl: data.isPositionTpsl,
+      isTrigger: data.isTrigger,
+      triggerPx: parseNum(data.triggerPx),
+      triggerCondition: data.triggerCondition,
+      orderType: data.orderType
     }
-  })
+  }
+
+  return null;
 }

--- a/app/routes/chart/data/customDataFeed.ts
+++ b/app/routes/chart/data/customDataFeed.ts
@@ -7,7 +7,7 @@ import type {
 } from '~/tv/charting_library/charting_library';
 import { getHistoricalData } from './candleDataCache';
 import { mapResolutionToInterval, supportedResolutions } from './utils/utils';
-import { useWsObserver } from '~/hooks/useWsObserver';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
 import { processWSCandleMessage } from './processChartData';
 import type { SymbolInfoIF } from "~/utils/SymbolInfoIFs";
 
@@ -87,7 +87,7 @@ export const createDataFeed = (
         },
 
         subscribeBars: (symbolInfo, resolution, onTick) => {
-            subscribe('candle', {
+            subscribe(WsChannels.CANDLE, {
                 payload: {
                     coin: symbolInfo.ticker,
                     interval: mapResolutionToInterval(resolution),

--- a/app/routes/trade.module.css
+++ b/app/routes/trade.module.css
@@ -133,7 +133,8 @@
 }
 
 
-.wsUrlSelector, .walletSelector{
+.wsUrlSelector, .walletSelector, .wsToggle{
+  user-select: none;
   position: fixed;
   top: 1rem;
   right: 20rem;
@@ -149,6 +150,26 @@
 .walletSelector{
   right: 38rem;
 }
+
+.wsToggle{
+  transition: all 0.2s ease;
+  right: 46rem; 
+  top: 1.2rem;
+  cursor: pointer;
+}
+
+.wsToggleRunning{
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.wsTogglePaused{
+  border-color: var(--red);
+  color: var(--red);
+}
+
+
+
 
 
 

--- a/app/routes/trade.tsx
+++ b/app/routes/trade.tsx
@@ -41,7 +41,7 @@ export default function Trade({ loaderData }: Route.ComponentProps) {
   const { orderBookMode } = useAppSettings();
 
 
-  const { wsUrl, setWsUrl, debugWallet, setDebugWallet } = useDebugStore();
+  const { wsUrl, setWsUrl, debugWallet, setDebugWallet, isWsEnabled, setIsWsEnabled } = useDebugStore();
 
 
     
@@ -79,6 +79,14 @@ export default function Trade({ loaderData }: Route.ComponentProps) {
   onChange={(value) => setDebugWallet({label: value, address: debugWallets.find((wallet) => wallet.label === value)?.address || ''})}
 />
 </div>
+
+<div className={`${styles.wsToggle} ${isWsEnabled ? styles.wsToggleRunning : styles.wsTogglePaused}`}>
+  <div
+    className={styles.wsToggleButton}
+    onClick={() => setIsWsEnabled(!isWsEnabled)}
+  > {isWsEnabled ? 'WS Running' : 'Paused'}</div>
+</div>
+
     
       <TradeRouteHandler />
       {

--- a/app/routes/trade.tsx
+++ b/app/routes/trade.tsx
@@ -81,10 +81,9 @@ export default function Trade({ loaderData }: Route.ComponentProps) {
 />
 </div>
 
-<div className={`${styles.wsToggle} ${isWsEnabled ? styles.wsToggleRunning : styles.wsTogglePaused}`}>
+<div  className={`${styles.wsToggle} ${isWsEnabled ? styles.wsToggleRunning : styles.wsTogglePaused}`} onClick={() => setIsWsEnabled(!isWsEnabled)}>
   <div
     className={styles.wsToggleButton}
-    onClick={() => setIsWsEnabled(!isWsEnabled)}
   > {isWsEnabled ? 'WS Running' : 'Paused'}</div>
 </div>
 

--- a/app/routes/trade/orderbook/orderbook.tsx
+++ b/app/routes/trade/orderbook/orderbook.tsx
@@ -1,18 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useWebSocketContext } from '~/contexts/WebSocketContext';
-import OrderRow from './orderrow/orderrow';
-import styles from './orderbook.module.css';
-import { useWsObserver } from '~/hooks/useWsObserver';
+import BasicDivider from '~/components/Dividers/BasicDivider';
+import ComboBox from '~/components/Inputs/ComboBox/ComboBox';
+import { ApiEndpoints, useInfoApi } from '~/hooks/useInfoApi';
+import useNumFormatter from '~/hooks/useNumFormatter';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
 import { processOrderBookMessage, processUserOrder } from '~/processors/processOrderBook';
+import { useDebugStore } from '~/stores/DebugStore';
 import { useOrderBookStore } from '~/stores/OrderBookStore';
+import { useTradeDataStore } from '~/stores/TradeDataStore';
 import type { OrderBookMode, OrderDataIF, OrderRowResolutionIF } from '~/utils/orderbook/OrderBookIFs';
 import { getPrecisionForResolution, getResolutionListForPrice } from '~/utils/orderbook/OrderBookUtils';
-import ComboBox from '~/components/Inputs/ComboBox/ComboBox';
-import BasicDivider from '~/components/Dividers/BasicDivider';
-import { useInfoApi } from '~/hooks/useInfoApi';
-import { useTradeDataStore } from '~/stores/TradeDataStore';
-import useNumFormatter from '~/hooks/useNumFormatter';
-import { useDebugStore } from '~/stores/DebugStore';
+import styles from './orderbook.module.css';
+import OrderRow from './orderrow/orderrow';
 interface OrderBookProps {
   symbol: string;
   orderCount: number;
@@ -21,7 +20,7 @@ interface OrderBookProps {
 const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
     const { subscribe, unsubscribeAllByChannel} = useWsObserver();
-    const {fetchInfo} = useInfoApi();
+    const {fetchData} = useInfoApi();
     const [resolutions, setResolutions] = useState<OrderRowResolutionIF[]>([]);
     const resolutionsShouldReset = useRef(true);
     const [selectedResolution, setSelectedResolution] = useState<OrderRowResolutionIF | null>(null);
@@ -35,50 +34,14 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
     const { formatNum, decimalPrecision } = useNumFormatter();
 
+    const {isWsEnabled} = useDebugStore();
+
+    const isWsEnabledRef = useRef<boolean>(true);
+    isWsEnabledRef.current = isWsEnabled;
 
     const {buys, sells, setOrderBook} = useOrderBookStore();
     const {userOrders, setUserOrders, userSymbolOrders, addOrderToHistory} = useTradeDataStore();
     const userOrdersRef = useRef<OrderDataIF[]>([]);
-    const cancelsRef = useRef<Set<number>>(new Set<number>());
-    // userOrdersRef.current = userOrders;
-
-
-    // const updateUserOrders = (updates: OrderDataIF[]) => {
-
-     
-    //   updates.filter(e=> e.status === 'open').map(e=> {
-    //     const index = userOrdersRef.current.findIndex(o => o.coin === e.coin && o.limitPx === e.limitPx);
-    //     if (index >= 0) {
-    //       userOrdersRef.current.splice(index, 1);
-    //       userOrdersRef.current.push(e);
-    //     }
-    //     else{
-    //       userOrdersRef.current.push(e);
-    //     }
-    //   });
-
-    //   updates.filter(e=> e.status === 'canceled').map(e=> {
-    //     const index = userOrdersRef.current.findIndex(o => o.oid === e.oid);
-    //     if (index !== -1) {
-    //       userOrdersRef.current.splice(index, 1);
-    //     }
-    //   });
-
-
-    //   console.log('>>> updates', updates.length, ' cancels', updates.filter(e=> e.status === 'canceled').length, 
-    //   ' opens', updates.filter(e=> e.status === 'open').length);
-
-    //   console.log('>>> userOrdersRef', userOrdersRef.current.length);
-    // }
-
-
-    // const removeFills = useCallback((fills: OrderDataIF[]) => {
-    //   const currentOrders = userOrdersRef.current;
-    //   const reducedOrders = currentOrders.filter((e:OrderDataIF)=> !fills.some(f=> f.oid === e.oid));
-    //   userOrdersRef.current = reducedOrders;
-
-    //   console.log('>>> removed fills', fills.length, ' current', currentOrders.length, ' reduced', reducedOrders.length);
-    // }, [])
 
     const buySlots = useMemo(() => {
       return buys.map((order) => order.px);
@@ -163,15 +126,16 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
       return slots;
     }, [userSymbolOrders, filledResolution.current, JSON.stringify(sellSlots)])
 
-    useEffect(() => {
-
-      // console.log('>>> user symbol orders', userSymbolOrders);
-    }, [userSymbolOrders])
 
     const changeSubscription = (payload: any) => {
-      subscribe('l2Book', 
+      subscribe(WsChannels.ORDERBOOK, 
         {payload: payload,
         handler: (response) => {
+          
+          if(!isWsEnabledRef.current){
+            return;
+          }
+
           filledResolution.current = payload.resolution;
           const {sells, buys} = processOrderBookMessage(response, orderCount);
           setOrderBook(buys, sells);
@@ -189,12 +153,6 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
         clearInterval(orderProcessorIntervalRef.current);
       }
 
-      // orderProcessorIntervalRef.current = setInterval(() => {
-      //   console.log('>>> userOrdersRef', userOrdersRef.current.length);
-      //   setUserOrders(userOrdersRef.current);
-
-      // }, 5000);
-
       return () => {
         if(orderProcessorIntervalRef.current){
           clearInterval(orderProcessorIntervalRef.current);
@@ -203,10 +161,10 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
     }, [])
 
 
-    const fetchOpenOrders = useCallback((saveIntoOrderHistory: boolean = false) => {
+    const fetchOpenOrders = useCallback(() => {
       
-      fetchInfo({
-        type: 'frontendOpenOrders',
+      fetchData({
+        type: ApiEndpoints.OPEN_ORDERS,
         payload: {
           user: debugWallet.address
         },
@@ -221,9 +179,6 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
               }
             })
             setUserOrders(userOrders);
-            if(saveIntoOrderHistory){
-              addOrderToHistory(userOrders);
-            }
           }
         }
       })
@@ -231,30 +186,12 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
     useEffect(() => {
 
-      fetchOpenOrders(true);
-
-
+      fetchOpenOrders();
       const intervalRef = setInterval(() => {
-        fetchOpenOrders(false);
+        if(!isWsEnabledRef.current){ return; }
+        fetchOpenOrders();
       }, 1000);
 
-      // subscribe('userFills', {
-      //   payload: {
-      //     user: debugWallet.address
-      //   },
-      //   handler: (payload) => {
-      //     const fills:OrderDataIF[] = [];
-      //     if(payload && payload.fills && payload.fills.length > 0){
-      //       payload.fills.map((fill:any) => {
-      //         const processedFill = processUserOrder(fill, 'filled');
-      //         if(processedFill){
-      //           fills.push(processedFill);
-      //         }
-      //       })
-      //     }
-      //     removeFills(fills);
-      //   }
-      // })
       return () => {
         clearInterval(intervalRef);
         unsubscribeAllByChannel('l2Book');

--- a/app/routes/trade/orderbook/orderbook.tsx
+++ b/app/routes/trade/orderbook/orderbook.tsx
@@ -39,7 +39,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
     const {buys, sells, setOrderBook} = useOrderBookStore();
     const {userOrders, setUserOrders, userSymbolOrders, removeFills} = useTradeDataStore();
     const userOrdersRef = useRef<OrderDataIF[]>([]);
-    userOrdersRef.current = userOrders;
+    // userOrdersRef.current = userOrders;
 
 
     const updateUserOrders = useCallback((updates: OrderDataIF[]) => {
@@ -51,7 +51,6 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
       const newOrders = updates.filter(e=> e.status === 'open' && !notCancelledSet.has(e.cloid) && !currentOrdersSet.has(e.cloid));
       const updatedOrders = [...notCancelled, ...newOrders];
       userOrdersRef.current = updatedOrders;
-      console.log('>>> updatedOrders', updatedOrders.length);
 
       // if(new Date().getTime() % 100 === 77){
       //   console.log('>>> userOrdersRef', userOrdersRef.current.length);
@@ -84,7 +83,9 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
     useEffect(() => {
 
-      console.log('>>> user orders', userOrders.length);
+      if(!userOrdersRef.current){
+        userOrdersRef.current = userOrders;
+      }
     }, [userOrders])
 
     const userBuySlots:Set<string> = useMemo(() => {
@@ -143,7 +144,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
     useEffect(() => {
 
-      console.log('>>> user symbol orders', userSymbolOrders);
+      // console.log('>>> user symbol orders', userSymbolOrders);
     }, [userSymbolOrders])
 
     const changeSubscription = (payload: any) => {
@@ -157,6 +158,28 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
         single: true
       })
     }
+
+
+    const orderProcessorIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+
+      if(orderProcessorIntervalRef.current){
+        clearInterval(orderProcessorIntervalRef.current);
+      }
+
+      orderProcessorIntervalRef.current = setInterval(() => {
+        console.log('>>> userOrdersRef', userOrdersRef.current.length);
+        setUserOrders(userOrdersRef.current);
+
+      }, 5000);
+
+      return () => {
+        if(orderProcessorIntervalRef.current){
+          clearInterval(orderProcessorIntervalRef.current);
+        }
+      }
+    }, [])
 
     useEffect(() => {
 

--- a/app/routes/trade/orderbook/orderbook.tsx
+++ b/app/routes/trade/orderbook/orderbook.tsx
@@ -221,6 +221,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
               }
             })
             setUserOrders(userOrders);
+            addOrderToHistory(userOrders);
           }
         }
       })
@@ -235,7 +236,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
         fetchOpenOrders();
       }, 1000);
 
-      subscribe('userHistoricalOrders', {
+      subscribe('userHistoricalOrders', { 
         payload: {
           user: debugWallet.address
         },

--- a/app/routes/trade/orderbook/orderbook.tsx
+++ b/app/routes/trade/orderbook/orderbook.tsx
@@ -37,7 +37,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
 
     const {buys, sells, setOrderBook} = useOrderBookStore();
-    const {userOrders, setUserOrders, userSymbolOrders} = useTradeDataStore();
+    const {userOrders, setUserOrders, userSymbolOrders, addOrderToHistory} = useTradeDataStore();
     const userOrdersRef = useRef<OrderDataIF[]>([]);
     const cancelsRef = useRef<Set<number>>(new Set<number>());
     // userOrdersRef.current = userOrders;
@@ -235,26 +235,23 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
         fetchOpenOrders();
       }, 1000);
 
-      // subscribe('userHistoricalOrders', {
-      //   payload: {
-      //     user: debugWallet.address
-      //   },
-      //   handler: (payload) => {
-      //     if(payload && payload.orderHistory && payload.orderHistory.length > 0){
-      //       const orderUpdates: OrderDataIF[] = [];
-      //       payload.orderHistory.map((o:any) => {
-      //         const processedOrder = processUserOrder(o.order, o.status);
-      //         if(processedOrder){
-      //           orderUpdates.push(processedOrder);
-      //         }
-      //         updateUserOrders(orderUpdates);
-      //       })
-
-      //       // console.log('>>> order updates', orderUpdates);
-      //       // updateUserOrders(orderUpdates);
-      //     }
-      //   }
-      // })
+      subscribe('userHistoricalOrders', {
+        payload: {
+          user: debugWallet.address
+        },
+        handler: (payload) => {
+          if(payload && payload.orderHistory && payload.orderHistory.length > 0){
+            const orderUpdates: OrderDataIF[] = [];
+            payload.orderHistory.map((o:any) => {
+              const processedOrder = processUserOrder(o.order, o.status);
+              if(processedOrder){
+                orderUpdates.push(processedOrder);
+              }
+            })
+            addOrderToHistory(orderUpdates);
+          }
+        }
+      })
 
       // subscribe('userFills', {
       //   payload: {

--- a/app/routes/trade/orderbook/orderbook.tsx
+++ b/app/routes/trade/orderbook/orderbook.tsx
@@ -203,7 +203,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
     }, [])
 
 
-    const fetchOpenOrders = useCallback(() => {
+    const fetchOpenOrders = useCallback((saveIntoOrderHistory: boolean = false) => {
       
       fetchInfo({
         type: 'frontendOpenOrders',
@@ -221,7 +221,9 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
               }
             })
             setUserOrders(userOrders);
-            addOrderToHistory(userOrders);
+            if(saveIntoOrderHistory){
+              addOrderToHistory(userOrders);
+            }
           }
         }
       })
@@ -229,30 +231,12 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
     useEffect(() => {
 
-      fetchOpenOrders();
+      fetchOpenOrders(true);
 
 
       const intervalRef = setInterval(() => {
-        fetchOpenOrders();
+        fetchOpenOrders(false);
       }, 1000);
-
-      subscribe('userHistoricalOrders', { 
-        payload: {
-          user: debugWallet.address
-        },
-        handler: (payload) => {
-          if(payload && payload.orderHistory && payload.orderHistory.length > 0){
-            const orderUpdates: OrderDataIF[] = [];
-            payload.orderHistory.map((o:any) => {
-              const processedOrder = processUserOrder(o.order, o.status);
-              if(processedOrder){
-                orderUpdates.push(processedOrder);
-              }
-            })
-            addOrderToHistory(orderUpdates);
-          }
-        }
-      })
 
       // subscribe('userFills', {
       //   payload: {

--- a/app/routes/trade/orderbook/orderbooktrades.tsx
+++ b/app/routes/trade/orderbook/orderbooktrades.tsx
@@ -1,5 +1,5 @@
 
-import { useWsObserver } from '~/hooks/useWsObserver';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
 import styles from './orderbooktrades.module.css';
 import { useCallback, useEffect, useRef } from 'react';
 import { useOrderBookStore } from '~/stores/OrderBookStore';
@@ -46,7 +46,7 @@ const OrderBookTrades: React.FC<OrderBookTradesProps> = ({ symbol, tradesCount }
   }, [symbol, tradesCount])
 
   useEffect(() => {
-    subscribe('trades', {
+    subscribe(WsChannels.ORDERBOOK_TRADES, {
       payload: {coin: symbol},
       handler: (payload) => {
         mergeTrades(processOrderBookTrades(payload));

--- a/app/routes/trade/symbol/symbolinfo.tsx
+++ b/app/routes/trade/symbol/symbolinfo.tsx
@@ -1,7 +1,7 @@
 import { useTradeDataStore } from '~/stores/TradeDataStore';
 import styles from './symbolinfo.module.css';
 import ComboBox from '~/components/Inputs/ComboBox/ComboBox';
-import { useWsObserver } from '~/hooks/useWsObserver';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
 import { useEffect } from 'react';
 import { processSymbolInfo } from '~/processors/processSymbolInfo';
 import SymbolInfoField from './symbolinfofield/symbolinfofield';
@@ -46,7 +46,7 @@ const SymbolInfo: React.FC<SymbolInfoProps> = ({ }) => {
   }, [])
 
   useEffect(() => {
-    subscribe('activeAssetCtx', {
+    subscribe(WsChannels.ACTIVE_COIN_DATA, {
       payload: {coin: symbol},
       handler: (payload) => {
         if(payload.coin === symbol){

--- a/app/routes/trade/trademodules/trademodules.tsx
+++ b/app/routes/trade/trademodules/trademodules.tsx
@@ -27,7 +27,7 @@ const TradeModules: React.FC<TradeModulesProps> = () => {
       {
         userSymbolOrders.filter((order) => order.side === 'sell').sort((a, b) => b.limitPx - a.limitPx).map((order) => {
           return (
-            <div key={order.cloid} style={{color: 'var(--red)'}}>
+            <div key={order.oid} style={{color: 'var(--red)'}}>
               {order.limitPx}
             </div>
           )
@@ -36,7 +36,7 @@ const TradeModules: React.FC<TradeModulesProps> = () => {
       {
         userSymbolOrders.filter((order) => order.side === 'buy').sort((a, b) => b.limitPx - a.limitPx).map((order) => {
           return (
-            <div key={order.cloid} style={{color: 'var(--green)'}}>
+            <div key={order.oid} style={{color: 'var(--green)'}}>
               {order.limitPx}
             </div>
           )

--- a/app/routes/trade/watchlist/watchlist.tsx
+++ b/app/routes/trade/watchlist/watchlist.tsx
@@ -1,7 +1,7 @@
 import { useTradeDataStore } from '~/stores/TradeDataStore';
 import styles from './watchlist.module.css';
 import ComboBox from '~/components/Inputs/ComboBox/ComboBox';
-import { useWsObserver } from '~/hooks/useWsObserver';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
 import { useEffect, useRef, useState } from 'react';
 import { processSymbolInfo } from '~/processors/processSymbolInfo';
 import { TbHeartFilled } from 'react-icons/tb';
@@ -72,7 +72,7 @@ const WatchList: React.FC<WatchListProps> = ({}) => {
     };
 
     useEffect(() => {
-        subscribe('webData2', {
+        subscribe(WsChannels.COINS, {
             payload: { user: '0x0000000000000000000000000000000000000000' },
             handler: (payload) => {
                 processWebData2Message(payload);

--- a/app/stores/DebugStore.ts
+++ b/app/stores/DebugStore.ts
@@ -15,7 +15,7 @@ interface DebugStore {
 }
 
 export const useDebugStore = create<DebugStore>((set) => ({
-    wsUrl: wsUrls[0],
+    wsUrl: wsUrls[2],
     setWsUrl: (wsUrl: string) => set({ wsUrl }),
     debugWallet: debugWallets[1],
     setDebugWallet: (debugWallet: DebugWallet) => set({ debugWallet })

--- a/app/stores/DebugStore.ts
+++ b/app/stores/DebugStore.ts
@@ -1,5 +1,4 @@
-import {create} from 'zustand';
-import type { OrderBookTradeIF, OrderBookRowIF } from '~/utils/orderbook/OrderBookIFs';
+import { create } from 'zustand';
 
 import { debugWallets, wsUrls } from '~/utils/Constants';
 
@@ -18,6 +17,6 @@ interface DebugStore {
 export const useDebugStore = create<DebugStore>((set) => ({
     wsUrl: wsUrls[0],
     setWsUrl: (wsUrl: string) => set({ wsUrl }),
-    debugWallet: debugWallets[0],
+    debugWallet: debugWallets[1],
     setDebugWallet: (debugWallet: DebugWallet) => set({ debugWallet })
 }));

--- a/app/stores/DebugStore.ts
+++ b/app/stores/DebugStore.ts
@@ -12,11 +12,15 @@ interface DebugStore {
     setWsUrl: (wsUrl: string) => void;
     debugWallet: DebugWallet;
     setDebugWallet: (debugWallet: DebugWallet) => void;
+    isWsEnabled: boolean;
+    setIsWsEnabled: (isWsEnabled: boolean) => void;
 }
 
 export const useDebugStore = create<DebugStore>((set) => ({
     wsUrl: wsUrls[2],
     setWsUrl: (wsUrl: string) => set({ wsUrl }),
     debugWallet: debugWallets[1],
-    setDebugWallet: (debugWallet: DebugWallet) => set({ debugWallet })
+    setDebugWallet: (debugWallet: DebugWallet) => set({ debugWallet }),
+    isWsEnabled: true,
+    setIsWsEnabled: (isWsEnabled: boolean) => set({ isWsEnabled })
 }));

--- a/app/stores/UserOrderStore.ts
+++ b/app/stores/UserOrderStore.ts
@@ -7,6 +7,7 @@ export interface UserTradeStore {
     setUserSymbolOrders: (userSymbolOrders: OrderDataIF[]) => void;
     orderHistory: OrderDataIF[];
     addOrderToHistory: (orderHistory: OrderDataIF[]) => void;
+    setOrderHistory: (orderHistory: OrderDataIF[]) => void;
 }
 
 export const createUserTradesSlice = (set:any, get:any) => ({
@@ -24,6 +25,9 @@ export const createUserTradesSlice = (set:any, get:any) => ({
         const newOrderHistory = [...newOrders, ...get().orderHistory].slice(0, 50);
         newOrderHistory.sort((a, b) => b.timestamp - a.timestamp);
         set({ orderHistory: newOrderHistory })
+    },
+    setOrderHistory: (orderHistory: OrderDataIF[]) => {
+        set({ orderHistory })
     }
 });
 

--- a/app/stores/UserOrderStore.ts
+++ b/app/stores/UserOrderStore.ts
@@ -5,8 +5,8 @@ export interface UserTradeStore {
     userSymbolOrders: OrderDataIF[];
     setUserOrders: (userOrders: OrderDataIF[]) => void;
     setUserSymbolOrders: (userSymbolOrders: OrderDataIF[]) => void;
-    updateUserOrders: (userOrders: OrderDataIF[]) => void;
-    removeFills: (fills: OrderDataIF[]) => void;
+    orderHistory: OrderDataIF[];
+    addOrderToHistory: (orderHistory: OrderDataIF[]) => void;
 }
 
 export const createUserTradesSlice = (set:any, get:any) => ({
@@ -19,28 +19,9 @@ export const createUserTradesSlice = (set:any, get:any) => ({
     setUserSymbolOrders: (userSymbolOrders: OrderDataIF[]) => {
         set({ userSymbolOrders })
     },
-    updateUserOrders: (updates: OrderDataIF[]) => {
-        const currentOrders = get().userOrders;
-        const cancels = new Set(updates.filter(e=> e.status === 'canceled').map(e=> e.cloid));
-        // console.log('>>> cancels', cancels);
-        const notCancelled = currentOrders.filter((e:OrderDataIF)=> !cancels.has(e.cloid));
-        const notCancelledSet = new Set(notCancelled.map(e=> e.cloid));
-        const currentOrdersSet = new Set(currentOrders.map(e=> e.cloid));
-        // console.log('>>> notCancelled', notCancelled);
-        const newOrders = updates.filter(e=> e.status === 'open' && !notCancelledSet.has(e.cloid) && !currentOrdersSet.has(e.cloid));
-        // const newOrders:OrderDataIF[] = [];
-        const updatedOrders = [...notCancelled, ...newOrders];
-        console.log('>>> updatedOrders', updatedOrders);
-        console.log('>>> updatedOrders uniqui ids', new Set(updatedOrders.map(e=> e.cloid)).size);
-        set({ userOrders: updatedOrders })
-
-        get().setUserSymbolOrders(updatedOrders.filter(e=> e.coin === get().symbol))
-    },
-    removeFills: (fills: OrderDataIF[]) => {
-        const currentOrders = get().userOrders;
-        const reducedOrders = currentOrders.filter((e:OrderDataIF)=> !fills.some(f=> f.cloid === e.cloid));
-        set({ userOrders: reducedOrders })
-        get().setUserSymbolOrders(reducedOrders.filter((e:OrderDataIF)=> e.coin === get().symbol))
+    orderHistory: [],
+    addOrderToHistory: (newOrders: OrderDataIF[]) => {
+        set({ orderHistory: [...newOrders, ...get().orderHistory].slice(0, 50) })
     }
 });
 

--- a/app/stores/UserOrderStore.ts
+++ b/app/stores/UserOrderStore.ts
@@ -21,7 +21,9 @@ export const createUserTradesSlice = (set:any, get:any) => ({
     },
     orderHistory: [],
     addOrderToHistory: (newOrders: OrderDataIF[]) => {
-        set({ orderHistory: [...newOrders, ...get().orderHistory].slice(0, 50) })
+        const newOrderHistory = [...newOrders, ...get().orderHistory].slice(0, 50);
+        newOrderHistory.sort((a, b) => b.timestamp - a.timestamp);
+        set({ orderHistory: newOrderHistory })
     }
 });
 

--- a/app/stores/UserOrderStore.ts
+++ b/app/stores/UserOrderStore.ts
@@ -1,3 +1,4 @@
+import { OrderHistoryLimits } from '~/utils/Constants';
 import type { OrderDataIF } from '~/utils/orderbook/OrderBookIFs';
 
 export interface UserTradeStore {
@@ -8,6 +9,9 @@ export interface UserTradeStore {
     orderHistory: OrderDataIF[];
     addOrderToHistory: (orderHistory: OrderDataIF[]) => void;
     setOrderHistory: (orderHistory: OrderDataIF[]) => void;
+    filterOrderHistory: (orderHistory: OrderDataIF[], filterType?: string) => OrderDataIF[];
+    userSymbolOrderHistory: OrderDataIF[];
+    setUserSymbolOrderHistory: (userSymbolOrderHistory: OrderDataIF[]) => void;
 }
 
 export const createUserTradesSlice = (set:any, get:any) => ({
@@ -22,12 +26,30 @@ export const createUserTradesSlice = (set:any, get:any) => ({
     },
     orderHistory: [],
     addOrderToHistory: (newOrders: OrderDataIF[]) => {
-        const newOrderHistory = [...newOrders, ...get().orderHistory].slice(0, 50);
+        const newOrderHistory = [...newOrders, ...get().orderHistory].slice(0, OrderHistoryLimits.MAX);
         newOrderHistory.sort((a, b) => b.timestamp - a.timestamp);
+        set({userSymbolOrderHistory: [...newOrderHistory.filter(e=> e.coin === get().symbol), 
+            ...get().userSymbolOrderHistory].slice(0, OrderHistoryLimits.RENDERED)})
         set({ orderHistory: newOrderHistory })
     },
     setOrderHistory: (orderHistory: OrderDataIF[]) => {
         set({ orderHistory })
+        set({ userSymbolOrderHistory: orderHistory.filter(e=> e.coin === get().symbol).slice(0, OrderHistoryLimits.RENDERED) })
+    },
+    filterOrderHistory: (orderHistory: OrderDataIF[], filterType?: string) => {
+        if(!filterType){
+            return orderHistory.slice(0, OrderHistoryLimits.RENDERED);
+        }
+        switch(filterType){
+            case 'all':
+                return orderHistory.slice(0, OrderHistoryLimits.RENDERED);
+            case 'active':
+                return get().userSymbolOrderHistory.slice(0, OrderHistoryLimits.RENDERED);
+            case 'long':
+                return orderHistory.filter(e=> e.side === 'buy').slice(0, OrderHistoryLimits.RENDERED);
+            case 'short':
+                return orderHistory.filter(e=> e.side === 'sell').slice(0, OrderHistoryLimits.RENDERED);
+        }
     }
 });
 

--- a/app/stores/UserOrderStore.ts
+++ b/app/stores/UserOrderStore.ts
@@ -5,6 +5,8 @@ export interface UserTradeStore {
     userSymbolOrders: OrderDataIF[];
     setUserOrders: (userOrders: OrderDataIF[]) => void;
     setUserSymbolOrders: (userSymbolOrders: OrderDataIF[]) => void;
+    updateUserOrders: (userOrders: OrderDataIF[]) => void;
+    removeFills: (fills: OrderDataIF[]) => void;
 }
 
 export const createUserTradesSlice = (set:any, get:any) => ({
@@ -16,6 +18,29 @@ export const createUserTradesSlice = (set:any, get:any) => ({
     },
     setUserSymbolOrders: (userSymbolOrders: OrderDataIF[]) => {
         set({ userSymbolOrders })
+    },
+    updateUserOrders: (updates: OrderDataIF[]) => {
+        const currentOrders = get().userOrders;
+        const cancels = new Set(updates.filter(e=> e.status === 'canceled').map(e=> e.cloid));
+        // console.log('>>> cancels', cancels);
+        const notCancelled = currentOrders.filter((e:OrderDataIF)=> !cancels.has(e.cloid));
+        const notCancelledSet = new Set(notCancelled.map(e=> e.cloid));
+        const currentOrdersSet = new Set(currentOrders.map(e=> e.cloid));
+        // console.log('>>> notCancelled', notCancelled);
+        const newOrders = updates.filter(e=> e.status === 'open' && !notCancelledSet.has(e.cloid) && !currentOrdersSet.has(e.cloid));
+        // const newOrders:OrderDataIF[] = [];
+        const updatedOrders = [...notCancelled, ...newOrders];
+        console.log('>>> updatedOrders', updatedOrders);
+        console.log('>>> updatedOrders uniqui ids', new Set(updatedOrders.map(e=> e.cloid)).size);
+        set({ userOrders: updatedOrders })
+
+        get().setUserSymbolOrders(updatedOrders.filter(e=> e.coin === get().symbol))
+    },
+    removeFills: (fills: OrderDataIF[]) => {
+        const currentOrders = get().userOrders;
+        const reducedOrders = currentOrders.filter((e:OrderDataIF)=> !fills.some(f=> f.cloid === e.cloid));
+        set({ userOrders: reducedOrders })
+        get().setUserSymbolOrders(reducedOrders.filter((e:OrderDataIF)=> e.coin === get().symbol))
     }
 });
 

--- a/app/utils/Constants.ts
+++ b/app/utils/Constants.ts
@@ -63,7 +63,8 @@ export const Langs: LangType[] = [
 
 export const wsUrls = [
     'wss://api.hyperliquid.xyz/ws',
-    'wss://pulse-api-mock.liquidity.tools/ws'
+    'wss://pulse-api-mock.liquidity.tools/ws',
+    'wss://api-ui.hyperliquid.xyz/ws'
 ]
 
 export const debugWallets: DebugWallet[] = [

--- a/app/utils/Constants.ts
+++ b/app/utils/Constants.ts
@@ -99,3 +99,7 @@ export const buySellColors: BuySellColor[] = [
 
 
 
+export const OrderHistoryLimits = {
+    MAX: 1000,
+    RENDERED: 50
+}

--- a/app/utils/Constants.ts
+++ b/app/utils/Constants.ts
@@ -72,6 +72,10 @@ export const debugWallets: DebugWallet[] = [
         address: '0xECB63caA47c7c4E77F60f1cE858Cf28dC2B82b00'
     },
     {
+        label: 'Crazy 2',
+        address: '0x023a3d058020fb76cca98f01b3c48c8938a22355'
+    },
+    {
         label: 'Benjamin Hyper',
         address: '0x1cFd5AAa6893f7d91e2A0aA073EB7f634e871353'
     },

--- a/app/utils/orderbook/OrderBookIFs.ts
+++ b/app/utils/orderbook/OrderBookIFs.ts
@@ -41,7 +41,7 @@ export interface OrderDataIF {
   timestamp: number;
   triggerCondition?: string;
   triggerPx?: number;
-  status: number;
+  status: string;
 
 }
 

--- a/app/utils/orderbook/OrderBookIFs.ts
+++ b/app/utils/orderbook/OrderBookIFs.ts
@@ -37,6 +37,7 @@ export interface OrderDataIF {
   reduceOnly? :boolean;
   side: 'buy' | 'sell';
   sz: number;
+  filledSz?: number; // only used for filled orders
   tif?: string;
   timestamp: number;
   triggerCondition?: string;
@@ -44,5 +45,6 @@ export interface OrderDataIF {
   status: string;
 
 }
+
 
 export type OrderBookMode = 'symbol' | 'usd';


### PR DESCRIPTION
- Open orders live update with polling with `[API] frontendOpenOrders` service
- Order history initial fetch with `[API] historicalOrders` service, Live update with `[WS] userHistoricalOrders`
- Filtering actions for both table `All, Active, Long, Short`
- Enums added for API Endpoints and WS channels
- Websocket pause and related store variable added _(Pause has been handled for OrderBook and both table listener methods)_