### PR TITLE
Shifting issue on SymbolInfo and WatchList components

### DIFF
--- a/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
+++ b/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
@@ -214,3 +214,29 @@
         display: none;
     }
 }
+
+.fontDebug1{
+    display: block;
+    font-family: var(--font-family-main);
+}
+
+.fontDebugAzeret{
+    display: block;
+    font-family: var(--font-family-azeret);
+}
+.fontDebugChivo{
+    display: block;
+    font-family: var(--font-family-chivo);
+}
+.fontDebugLekton{
+    display: block;
+    font-family: var(--font-family-lekton);
+}
+.fontDebugB612{
+    display: block;
+    font-family: var(--font-family-b612);
+}
+.fontDebugCourier{    
+    display: block;
+    font-family: var(--font-family-courier);
+}

--- a/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
+++ b/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
@@ -107,6 +107,12 @@ export default function OrderHistoryTable(props: OrderHistoryTableProps) {
 
   return (
     <div className={styles.tableWrapper}>
+      <div className={styles.fontDebug1}>Main Font: 0123456789</div>
+      <div className={styles.fontDebugAzeret}>Azeret : 0123456789</div>
+      <div className={styles.fontDebugChivo}>Chivo : 0123456789</div>
+      <div className={styles.fontDebugLekton}>Lekton : 0123456789</div>
+      <div className={styles.fontDebugB612}>B612 : 0123456789</div>
+      <div className={styles.fontDebugCourier}>Courier : 0123456789</div>
       <OrderHistoryTableHeader />
       <div className={styles.tableBody}>
         {orderHistoryToShow.map((order, index) => (

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -1,6 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Lexend+Exa:wght@100;300;500&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Lexend+Deca:wght@100;300&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Chivo+Mono:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=B612+Mono:wght@400&display=swap'); 
+@import url('https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lekton:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400&display=swap');
 :root {
   /* Dark Shades */
   --dark1: #06060c;
@@ -48,7 +53,13 @@
   --trade-module-width-desktop-small: 280px;
 
   /* fonts */
-  --font-family-main: 'Lexend Deca';
+   --font-family-main: 'Lexend Deca';
+   --font-family-azeret: 'Azeret Mono';
+   --font-family-chivo: 'Chivo Mono';
+   --font-family-lekton: 'Lekton';
+   --font-family-b612: 'B612 Mono';
+   --font-family-courier: 'Courier Prime';
+  
 
   --font-size-xs: 10px;
   --font-size-s: 12px;

--- a/app/hooks/useNumFormatter.ts
+++ b/app/hooks/useNumFormatter.ts
@@ -18,9 +18,15 @@ export function useNumFormatter() {
   }, []);
 
   const getDefaultPrecision = useCallback((num: number | string) => {
-    const numVal = parseNum(num);
-    if(numVal > 1000000){
+    const numVal = Math.abs(parseNum(num));
+    if(numVal > 10000){
         return 0;
+    }
+    else if(numVal > 1000){
+        return 1;
+    }
+    else if(numVal > 100){
+        return 2; 
     }
     else if(numVal < 10){
         return 4;
@@ -49,14 +55,14 @@ export function useNumFormatter() {
       precisionVal = precision;
     }
     
-    if (Number.isInteger(num)) {
-      return num.toLocaleString(formatType);
-    } else {
+    // if (Number.isInteger(num)) {
+    //   return num.toLocaleString(formatType);
+    // } else {
       return num.toLocaleString(formatType, {
         minimumFractionDigits: precisionVal || getDefaultPrecision(num),
         maximumFractionDigits: precisionVal || getDefaultPrecision(num)
       });
-    }
+    // }
 
   }, [numFormat, parseNum, getDefaultPrecision]);
 
@@ -67,7 +73,7 @@ export function useNumFormatter() {
   
 
 
-  return { formatNum, formatPriceForChart, decimalPrecision };
+  return { formatNum, formatPriceForChart, decimalPrecision, getDefaultPrecision };
 }
 
 export default useNumFormatter;

--- a/app/routes/trade/orderbook/orderrow/orderrow.module.css
+++ b/app/routes/trade/orderbook/orderrow/orderrow.module.css
@@ -35,10 +35,13 @@
     justify-content: space-between;
     width: 100%;
     position: relative;
-    font-size: .8rem;
     /* animation: fadeIn 0.1s ease-in-out; */
     padding: 0 .5rem;
     cursor: pointer;
+     /* font-family: var(--font-family-mono);
+    letter-spacing: -.05rem; */
+    /* font-family: var(--font-family-main); */
+    /* font-family: var(--font-family-chivo); */
 }
 
 
@@ -108,4 +111,18 @@
     height: 4px;
     border-radius: 100%;
     background-color: white;
+    background-color: #e9e980;
+    opacity: .4;
 }
+
+
+.userOrder .orderRowPrice {
+    color:  #e9e980 !important;
+}
+
+
+.userOrder{
+    /* border: 1px solid #e9e98055; */
+}
+
+

--- a/app/routes/trade/orderbook/orderrow/orderrow.tsx
+++ b/app/routes/trade/orderbook/orderrow/orderrow.tsx
@@ -41,7 +41,7 @@ const OrderRow: React.FC<OrderRowProps> = ({ order, coef, resolution, userSlots 
     });
   }
   return (
-    <div className={`${styles.orderRow} ${type}`} onClick={handleClick} >
+    <div className={`${styles.orderRow} ${type} ${userSlots.has(formattedPrice) ? styles.userOrder : ''}`} onClick={handleClick} >
       {userSlots.has(formattedPrice) && <div className={styles.userOrderIndicator}></div>}
       <div className={styles.orderRowPrice}>{formattedPrice}</div>
       <div className={styles.orderRowSize}>{formatNum(order.sz * coef)}</div>

--- a/app/routes/trade/symbol/symbolinfo.module.css
+++ b/app/routes/trade/symbol/symbolinfo.module.css
@@ -5,6 +5,7 @@
     font-size: .8rem;
     display: flex;
     flex-direction: row;
+    align-items: center;
 }
 
 .symbolInfoContainer div{

--- a/app/routes/trade/symbol/symbolinfo.tsx
+++ b/app/routes/trade/symbol/symbolinfo.tsx
@@ -35,7 +35,7 @@ const SymbolInfo: React.FC<SymbolInfoProps> = ({ }) => {
 
   const navigate = useNavigate();
 
-  const { formatNum } = useNumFormatter();
+  const { formatNum, getDefaultPrecision } = useNumFormatter();
 
   const { orderBookMode } = useAppSettings();
 
@@ -62,9 +62,10 @@ const SymbolInfo: React.FC<SymbolInfoProps> = ({ }) => {
     if(symbolInfo){
       const usdChange = symbolInfo.markPx - symbolInfo.prevDayPx;
       const percentChange = (usdChange / symbolInfo.prevDayPx) * 100;
-      return {str:  `${usdChange > 0 ? '+' : ''}${formatNum(usdChange)} / ${formatNum(percentChange, 2)}%`, usdChange};
+      const precision = getDefaultPrecision(symbolInfo.markPx);
+      return {str:  `${usdChange > 0 ? '+' : ''}${formatNum(usdChange, precision + 1)}/${formatNum(percentChange, 2)}%`, usdChange};
     }
-    return {str: '+0.0 / %0.0', usdChange: 0};
+    return {str: '+0.0/%0.0', usdChange: 0};
   }
 
   
@@ -92,8 +93,8 @@ const SymbolInfo: React.FC<SymbolInfoProps> = ({ }) => {
             <SymbolInfoField label="Mark" value={'$'+formatNum(symbolInfo?.markPx)} lastWsChange={symbolInfo?.lastPriceChange} />
             <SymbolInfoField label="Oracle" value={'$'+formatNum(symbolInfo?.oraclePx)} />
             <SymbolInfoField label="24h Change" value={get24hChangeString().str} type={get24hChangeString().usdChange > 0 ? 'positive' : get24hChangeString().usdChange < 0 ? 'negative' : undefined} />
-            <SymbolInfoField label="24h Volume" value={'$'+formatNum(symbolInfo?.dayNtlVlm, 2)} />
-            <SymbolInfoField label="Open Interest" value={'$'+formatNum(symbolInfo?.openInterest * symbolInfo?.oraclePx, 2)} />
+            <SymbolInfoField label="24h Volume" value={'$'+formatNum(symbolInfo?.dayNtlVlm, 0)} />
+            <SymbolInfoField label="Open Interest" value={'$'+formatNum(symbolInfo?.openInterest * symbolInfo?.oraclePx, 0)} />
             <SymbolInfoField label="Funding Rate" value={(symbolInfo?.funding * 100).toString().substring(0, 7)+'%'} type={symbolInfo?.funding < 0 ? 'positive' : symbolInfo?.funding > 0 ? 'negative' : undefined} />
             <SymbolInfoField label="Funding Countdown" value={getTimeUntilNextHour()} />
           </div>

--- a/app/routes/trade/symbol/symbolinfofield/symbolinfofield.module.css
+++ b/app/routes/trade/symbol/symbolinfofield/symbolinfofield.module.css
@@ -47,6 +47,8 @@
 
     color: var(--text1);
     margin-top: .2rem;
+    font-family: var(--font-family-chivo);
+    /* letter-spacing: -.04rem; */
 }
 
 .symbolInfoFieldValue.positiveAnimation {

--- a/app/routes/trade/watchlist/watchlistnode/watchlistnode.module.css
+++ b/app/routes/trade/watchlist/watchlistnode/watchlistnode.module.css
@@ -13,9 +13,12 @@
 }
 
 
-
+ 
 .symbolValue{
     margin-left: .5rem;
+    /* font-family: var(--font-family-azeret);
+    letter-spacing: -.04rem; */
+    font-family: var(--font-family-chivo);
 }
 
 .symbolValue.positive{


### PR DESCRIPTION
For the shifting issue on SymbolInfo and WatchList nodes monospaced fonts have been added for checking.

- `Chivo` font has been used for testing
- _Fonts can be compared on Order History table (temporary divs added for checking all monospace fonts)_
- Vertical alignment on SymbolInfo has been fixed.
- Marking user orders with yellow color




