### PR TITLE
Orderbook | New click handler to copy slot values into Trade Module

### DIFF
--- a/app/components/Trade/OrderInput/OrderInput.tsx
+++ b/app/components/Trade/OrderInput/OrderInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './OrderInput.module.css';
 import OrderDropdown from './OrderDropdown/OrderDropdown';
 import LeverageSlider from './LeverageSlider/LeverageSlider';
@@ -21,6 +21,8 @@ import ScaleOrders from './ScaleOrders/ScaleOrders';
 import evenSvg from '../../../assets/icons/EvenPriceDistribution.svg';
 import flatSvg from '../../../assets/icons/FlatPriceDistribution.svg';
 import ConfirmationModal from './ConfirmationModal/ConfirmationModal';
+import { useTradeDataStore } from '~/stores/TradeDataStore';
+import useNumFormatter from '~/hooks/useNumFormatter';
 export interface OrderTypeOption {
     value: string;
     label: string;
@@ -93,6 +95,9 @@ export default function OrderInput() {
         setTempMaximumLeverageInput(newMaximumInputValue);
     };
 
+    const { obChosenPrice, obChosenAmount, symbol } = useTradeDataStore();
+    const { formatNum } = useNumFormatter();
+
     const appSettingsModal: useModalIF = useModal('closed');
 
     const showPriceInputComponent = [
@@ -118,9 +123,38 @@ export default function OrderInput() {
         {
             label: 'Current Position',
             tooltipLabel: 'current position',
-            value: '0.000 ETH',
+            value: `0.000 ${symbol}`,
         },
     ];
+
+    useEffect(() => {
+        if (obChosenAmount > 0) {
+            setSize(formatNum(obChosenAmount));
+            handleTypeChange();
+        }
+        if (obChosenPrice > 0) {
+            console.log(obChosenPrice);
+            setPrice(obChosenPrice.toString());
+            handleTypeChange();
+        }
+    }, [obChosenAmount, obChosenPrice]);
+
+    useEffect(() => {
+        setSize('');
+        setPrice('');
+    }, [symbol]);
+
+    const handleTypeChange = () => {
+        switch (marketOrderType) {
+            case 'market':
+                setMarketOrderType('limit');
+                break;
+            case 'stop_market':
+                setMarketOrderType('stop_limit');
+                break;
+        }
+    };
+
     const openModalWithContent = (
         content: 'margin' | 'scale' | 'confirmation',
     ) => {
@@ -336,6 +370,7 @@ export default function OrderInput() {
         className: 'custom-input',
         ariaLabel: 'Size input',
         useTotalSize,
+        symbol,
     };
 
     const positionSizeProps = {

--- a/app/components/Trade/OrderInput/PlaceOrderButtons/PlaceOrderButtons.tsx
+++ b/app/components/Trade/OrderInput/PlaceOrderButtons/PlaceOrderButtons.tsx
@@ -8,6 +8,7 @@ interface propsIF {
     openModalWithContent: (
         content: 'margin' | 'scale' | 'confirmation',
     ) => void;
+    orderValue?: string;
 }
 interface MarketInfoItem {
     label: string;

--- a/app/components/Trade/OrderInput/SizeInput/SizeInput.tsx
+++ b/app/components/Trade/OrderInput/SizeInput/SizeInput.tsx
@@ -9,6 +9,7 @@ interface PropsIF {
     className?: string;
     ariaLabel?: string;
     useTotalSize: boolean;
+    symbol?: string;
 }
 export default function SizeInput(props: PropsIF) {
     const {
@@ -19,6 +20,7 @@ export default function SizeInput(props: PropsIF) {
         className,
         ariaLabel,
         useTotalSize,
+        symbol,
     } = props;
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = event.target.value;
@@ -42,7 +44,7 @@ export default function SizeInput(props: PropsIF) {
                 placeholder='Enter Size'
             />
             <button className={styles.tokenButton}>
-                ETH <FaChevronDown />
+                {symbol ? symbol : 'ETH'} <FaChevronDown />
             </button>
         </div>
     );

--- a/app/routes/trade/orderbook/orderrow/orderrow.module.css
+++ b/app/routes/trade/orderbook/orderrow/orderrow.module.css
@@ -37,7 +37,6 @@
     font-size: 0.8rem;
     /* animation: fadeIn 0.1s ease-in-out; */
     padding: 0 0.5rem;
-    cursor: pointer;
 }
 
 .orderRow .ratio {
@@ -47,12 +46,22 @@
     width: 100%;
     height: 100%;
     opacity: 0.2;
+    z-index: 0;
 }
 
 .orderRowPrice,
 .orderRowSize,
 .orderRowTotal {
     flex: 1 1;
+    z-index: 2;
+    cursor: pointer;
+    user-select: none;
+}
+
+.orderRowPrice:hover,
+.orderRowSize:hover,
+.orderRowTotal:hover {
+    font-weight: bold;
 }
 
 .orderRowTotal {

--- a/app/routes/trade/orderbook/orderrow/orderrow.tsx
+++ b/app/routes/trade/orderbook/orderrow/orderrow.tsx
@@ -9,17 +9,30 @@ import type {
 import styles from './orderrow.module.css';
 
 interface OrderRowProps {
+    rowIndex: number;
     order: OrderBookRowIF;
     coef: number;
     resolution: OrderRowResolutionIF | null;
     userSlots: Set<string>;
+    clickListener: (
+        order: OrderBookRowIF,
+        type: OrderRowClickTypes,
+        rowIndex: number,
+    ) => void;
+}
+
+export enum OrderRowClickTypes {
+    PRICE = 'price',
+    AMOUNT = 'amount',
 }
 
 const OrderRow: React.FC<OrderRowProps> = ({
+    rowIndex,
     order,
     coef,
     resolution,
     userSlots,
+    clickListener,
 }) => {
     const { formatNum } = useNumFormatter();
 
@@ -44,6 +57,16 @@ const OrderRow: React.FC<OrderRowProps> = ({
             className={`${styles.orderRow} ${userSlots.has(formattedPrice) ? styles.userOrder : ''}`}
             onClick={handleClick}
         >
+            <div
+                className={styles.ratio}
+                style={{
+                    width: `${order.ratio * 100}%`,
+                    backgroundColor:
+                        order.type === 'buy'
+                            ? getBsColor().buy
+                            : getBsColor().sell,
+                }}
+            ></div>
             {userSlots.has(formattedPrice) && (
                 <div className={styles.userOrderIndicator}></div>
             )}
@@ -55,25 +78,28 @@ const OrderRow: React.FC<OrderRowProps> = ({
                             ? getBsColor().buy
                             : getBsColor().sell,
                 }}
+                onClick={() =>
+                    clickListener(order, OrderRowClickTypes.PRICE, rowIndex)
+                }
             >
                 {formattedPrice}
             </div>
-            <div className={styles.orderRowSize}>
+            <div
+                className={styles.orderRowSize}
+                onClick={() =>
+                    clickListener(order, OrderRowClickTypes.AMOUNT, rowIndex)
+                }
+            >
                 {formatNum(order.sz * coef)}
             </div>
-            <div className={styles.orderRowTotal}>
+            <div
+                className={styles.orderRowTotal}
+                onClick={() =>
+                    clickListener(order, OrderRowClickTypes.AMOUNT, rowIndex)
+                }
+            >
                 {formatNum(order.total * coef)}
             </div>
-            <div
-                className={styles.ratio}
-                style={{
-                    width: `${order.ratio * 100}%`,
-                    backgroundColor:
-                        order.type === 'buy'
-                            ? getBsColor().buy
-                            : getBsColor().sell,
-                }}
-            ></div>
             {/* <div className={styles.fadeOverlay}></div> */}
         </div>
     );

--- a/app/stores/TradeDataStore.ts
+++ b/app/stores/TradeDataStore.ts
@@ -21,6 +21,10 @@ type TradeDataStore = UserTradeStore & {
     coins: SymbolInfoIF[];
     setCoins: (coins: SymbolInfoIF[]) => void;
     removeFromFavKeys: (coin: string) => void;
+    obChosenPrice: number;
+    setObChosenPrice: (price: number) => void;
+    obChosenAmount: number;
+    setObChosenAmount: (amount: number) => void;
 };
 
 const useTradeDataStore = create<TradeDataStore>()(
@@ -34,6 +38,7 @@ const useTradeDataStore = create<TradeDataStore>()(
                 get().setUserSymbolOrders(
                     get().userOrders.filter((e) => e.coin === symbol),
                 );
+                set({ obChosenPrice: 0, obChosenAmount: 0 });
             },
             symbolInfo: null,
             setSymbolInfo: (symbolInfo: SymbolInfoIF) => {
@@ -68,6 +73,11 @@ const useTradeDataStore = create<TradeDataStore>()(
             setFavCoins: (favs: SymbolInfoIF[]) => set({ favCoins: favs }),
             coins: [],
             setCoins: (coins: SymbolInfoIF[]) => set({ coins }),
+            obChosenPrice: 0,
+            setObChosenPrice: (price: number) => set({ obChosenPrice: price }),
+            obChosenAmount: 0,
+            setObChosenAmount: (amount: number) =>
+                set({ obChosenAmount: amount }),
         }),
         {
             name: 'TRADE_DATA',


### PR DESCRIPTION
New orderbook click handlers has been added

- Click by field (price, size, total)
- Store values has been added into TradeDataStore (`obChosenPrice`, `obChosenAmount`)
- Lock orderbook 1sec after clicking to make clear which row has been clicked
- Assign clicked values into Trade Module
- Change Trade Module `Order Type` if needed

Order Type change rules;
- Market -> Limit
- Stop Market -> Stop Limit

Copy Rules;
- Price click -> (Copy price into price input)
- Size & Total amount click (copy both price and amount into size and price inputs)
 For the size, sum of orders until selected order type (buy/sell) has been copied into size input (which means total size)