### PR TITLE
SDK | User order history

### DIFF
--- a/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
+++ b/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.tsx
@@ -1,16 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { ApiEndpoints, useInfoApi } from '~/hooks/useInfoApi';
+import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
+import { processUserOrder } from '~/processors/processOrderBook';
+import { useDebugStore } from '~/stores/DebugStore';
 import { useTradeDataStore } from '~/stores/TradeDataStore';
+import { OrderHistoryLimits } from '~/utils/Constants';
+import type { OrderDataIF } from '~/utils/orderbook/OrderBookIFs';
 import styles from './OrderHistoryTable.module.css';
 import OrderHistoryTableHeader from './OrderHistoryTableHeader';
 import OrderHistoryTableRow from './OrderHistoryTableRow';
 import { orderHistoryData } from './data';
-import { useWsObserver, WsChannels } from '~/hooks/useWsObserver';
-import { useDebugStore } from '~/stores/DebugStore';
-import type { OrderDataIF } from '~/utils/orderbook/OrderBookIFs';
-import { processUserOrder } from '~/processors/processOrderBook';
-import type { FilterOption } from '../TradeTables/TradeTables';
-import { ApiEndpoints, useInfoApi } from '~/hooks/useInfoApi';
-import { OrderHistoryLimits } from '~/utils/Constants';
 
 interface OrderHistoryTableProps {
     onViewAll?: () => void;

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -100,6 +100,11 @@ export interface NotificationSubscription {
     user: string;
 }
 
+export interface UserHistoricalOrdersSubscription {
+    type: 'userHistoricalOrders';
+    user: string;
+}
+
 export type Subscription =
     | AllMidsSubscription
     | L2BookSubscription
@@ -111,7 +116,8 @@ export type Subscription =
     | UserFundingsSubscription
     | UserNonFundingLedgerUpdatesSubscription
     | WebData2Subscription
-    | NotificationSubscription;
+    | NotificationSubscription
+    | UserHistoricalOrdersSubscription;
 
 export interface AllMidsData {
     mids: Record<string, string>;
@@ -221,6 +227,35 @@ export interface UserFillsMsg {
     data: UserFillsData;
 }
 
+export interface UserHistoricalOrdersData {
+    user: string;
+    orderHistory: OrderHistory[];
+}
+
+export interface OrderHistory {
+    order: OrderData;
+    status: string;
+    statusTimestamp: number;
+}
+
+export interface OrderData {
+    cloid: string;
+    coin: string;
+    isPositionTpsl?: boolean;
+    isTrigger?: boolean;
+    limitPx: number;
+    oid: number;
+    orderType: string;
+    origSz: number;
+    reduceOnly?: boolean;
+    side: 'buy' | 'sell';
+    sz: number;
+    tif?: string;
+    timestamp: number;
+    triggerCondition?: string;
+    triggerPx?: number;
+}
+
 export interface OtherWsMsg {
     channel:
         | 'candle'
@@ -236,6 +271,11 @@ export interface NotificationMsg {
     data: NotificationData;
 }
 
+export interface UserHistoricalOrdersMsg {
+    channel: 'userHistoricalOrders';
+    data: UserHistoricalOrdersData;
+}
+
 export type WsMsg =
     | AllMidsMsg
     | L2BookMsg
@@ -244,7 +284,8 @@ export type WsMsg =
     | PongMsg
     | UserFillsMsg
     | OtherWsMsg
-    | NotificationMsg;
+    | NotificationMsg
+    | UserHistoricalOrdersMsg;
 
 export interface BuilderInfo {
     b: string; // public address of the builder

--- a/packages/sdk/src/ws.ts
+++ b/packages/sdk/src/ws.ts
@@ -32,6 +32,8 @@ function subscriptionToIdentifier(subscription: Subscription): string {
             return `webData2:${subscription.user.toLowerCase()}`;
         case 'notification':
             return `notification:${subscription.user.toLowerCase()}`;
+        case 'userHistoricalOrders':
+            return `userHistoricalOrders:${subscription.user.toLowerCase()}`;
         default:
             throw new Error('Unknown subscription type');
     }
@@ -65,6 +67,8 @@ function wsMsgToIdentifier(wsMsg: WsMsg): string | undefined {
             return `webData2:${wsMsg.data.user.toLowerCase()}`;
         case 'notification':
             return 'notification';
+        case 'userHistoricalOrders':
+            return `userHistoricalOrders:${wsMsg.data.user.toLowerCase()}`;
         default:
             return undefined;
     }


### PR DESCRIPTION
UserOrderHistory channel-related types have been added to the SDK to fix the issue that was triggered when switching the Trades tab.