### PR TITLE
Fix shape dragging issue on chart

### DIFF
--- a/packages/frontend/app/routes/chart/orders/component/LineComponent.ts
+++ b/packages/frontend/app/routes/chart/orders/component/LineComponent.ts
@@ -267,7 +267,7 @@ const LineComponent = ({ lines }: LineProps) => {
                             activeQuantityLabel.setProperties({
                                 text: quantityText,
                                 wordWrapWidth:
-                                    estimateTextWidth(quantityText) + 5,
+                                    estimateTextWidth(quantityText) + 15,
                             });
                         }
                     }

--- a/packages/frontend/app/routes/chart/orders/component/LineComponent.ts
+++ b/packages/frontend/app/routes/chart/orders/component/LineComponent.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTradingView } from '~/contexts/TradingviewContext';
 
-import type { EntityId } from '~/tv/charting_library';
+import type { EntityId, IPaneApi } from '~/tv/charting_library';
 import {
     addCustomOrderLine,
     createAnchoredMainText,
@@ -79,6 +79,68 @@ const LineComponent = ({ lines }: LineProps) => {
     };
 
     const [chartReady, setChartReady] = useState(true);
+
+    const [zoomChanged, setZoomChanged] = useState(false);
+    const prevRangeRef = useRef<{ min: number; max: number } | null>(null);
+    const animationFrameRef = useRef<number>(0);
+    const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+    const isZoomingRef = useRef(false);
+
+    useEffect(() => {
+        if (!chart) return;
+
+        const chartRef = chart.activeChart();
+        const priceScalePane = chartRef.getPanes()[0] as IPaneApi;
+        const priceScale = priceScalePane.getMainSourcePriceScale();
+        if (!priceScale) return;
+
+        const loop = () => {
+            const priceRange = priceScale.getVisiblePriceRange();
+            if (priceRange) {
+                const currentRange = {
+                    min: priceRange.from,
+                    max: priceRange.to,
+                };
+
+                const prevRange = prevRangeRef.current;
+                const hasChanged =
+                    !prevRange ||
+                    prevRange.min !== currentRange.min ||
+                    prevRange.max !== currentRange.max;
+
+                if (hasChanged) {
+                    prevRangeRef.current = currentRange;
+
+                    if (!isZoomingRef.current) {
+                        isZoomingRef.current = true;
+                        setZoomChanged(true);
+                    }
+
+                    if (debounceTimerRef.current) {
+                        clearTimeout(debounceTimerRef.current);
+                    }
+
+                    debounceTimerRef.current = setTimeout(() => {
+                        isZoomingRef.current = false;
+                        setZoomChanged(false);
+                    }, 200);
+                }
+            }
+
+            animationFrameRef.current = requestAnimationFrame(loop);
+        };
+
+        animationFrameRef.current = requestAnimationFrame(loop);
+
+        return () => {
+            if (animationFrameRef.current) {
+                cancelAnimationFrame(animationFrameRef.current);
+            }
+            if (debounceTimerRef.current) {
+                clearTimeout(debounceTimerRef.current);
+            }
+        };
+    }, [chart]);
 
     useEffect(() => {
         let intervalId: NodeJS.Timeout | undefined = undefined;
@@ -226,13 +288,17 @@ const LineComponent = ({ lines }: LineProps) => {
             });
         };
 
-        updateTextPosition();
+        if (zoomChanged) {
+            updateTextPosition();
+        } else {
+            intervals.forEach(clearInterval);
+        }
 
         return () => {
             isCancelled = true;
             intervals.forEach(clearInterval);
         };
-    }, [orderLineItems, chart, lines]);
+    }, [orderLineItems, chart, lines, zoomChanged]);
 
     return null;
 };

--- a/packages/frontend/app/routes/chart/orders/customOrderLineUtils.ts
+++ b/packages/frontend/app/routes/chart/orders/customOrderLineUtils.ts
@@ -149,7 +149,7 @@ export const createQuantityAnchoredText = async (
         yPrice,
         text,
         '#000000',
-        estimateTextWidth(text) + 5,
+        estimateTextWidth(text) + 15,
         '#3C91FF',
         '#FFFFFF',
     );

--- a/packages/frontend/app/routes/chart/orders/openOrderLine.tsx
+++ b/packages/frontend/app/routes/chart/orders/openOrderLine.tsx
@@ -38,7 +38,7 @@ const OpenOrderLine = () => {
     }, [JSON.stringify(positions), symbol]);
 
     useEffect(() => {
-        if (!chart || !userSymbolOrders?.length || !pnlSzi) {
+        if (!chart || !userSymbolOrders?.length) {
             setLines([]);
             return;
         }
@@ -99,7 +99,7 @@ const OpenOrderLine = () => {
                     if (triggerPx) {
                         yPrice = triggerPx;
                     }
-                    quantityTextValue = sz ? sz : pnlSzi;
+                    quantityTextValue = sz ? sz : pnlSzi ? pnlSzi : 0;
                 }
 
                 return {


### PR DESCRIPTION
Fixes :
- Drawn shapes cant be drag
          1. Switch to Crazy Account
          2. Draw any shape using the drawing tool
          3. Try dragging the shape  

- Missing limit order lines for Benjamin Hyper account

İmprovment  :
- Quantity text width increased


