### PR TITLE
Positions Table | View all button to open positions in a separate page

### DIFF
--- a/packages/frontend/app/components/Pagination/Pagination.module.css
+++ b/packages/frontend/app/components/Pagination/Pagination.module.css
@@ -1,0 +1,172 @@
+.dropdownMenu,
+.dropupMenu {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    background-color: var(--dark3);
+    border-radius: var(--half-border-radius);
+    padding: 8px;
+    width: 100%;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    text-align: right;
+}
+
+.dropdownItem {
+    width: 100%;
+    padding: 8px;
+    color: var(--text1, #f0f0f8);
+    font-size: var(--font-size-s, 12px);
+    cursor: pointer;
+}
+
+.dropdownItem:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.paginationContainer {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+
+    font-size: var(--font-size-s, 12px);
+    color: var(--text1, #f0f0f8);
+    gap: 12px;
+    user-select: none;
+}
+
+.rowsPerPage {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.rowSelector {
+    background-color: var(--dark2, #1a1b23);
+    padding: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    position: relative;
+}
+
+.pageInfo {
+    color: var(--text1, #f0f0f8);
+}
+
+.pageButtons {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.pageButton {
+    background-color: transparent;
+    border: none;
+    color: var(--text2, #6a6a6d);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+}
+
+.pageButton:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--text1, #f0f0f8);
+}
+
+.pageButton:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.footer {
+    color: var(--text2, #bcbcc4);
+    text-align: center;
+
+    font-family: var(--font-family-main, 'Lexend Deca');
+    font-size: var(--font-size-s, 12px);
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    align-self: stretch;
+}
+.periodSelectorContainer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}
+
+.fullScreen {
+    margin-top: 0 !important;
+    gap: 8px !important;
+}
+
+.fullScreen .searchRow {
+    height: auto;
+}
+.expandIcon {
+    fill: var(--text2);
+}
+.expandIcon:hover {
+    fill: var(--text1);
+}
+.chvrDown {
+    display: none;
+}
+.chvrUp {
+    display: none;
+}
+
+@media (min-width: 1280px) {
+    .container {
+        width: 1165px;
+    }
+}
+@media (min-width: 1580px) {
+    .container {
+        margin-top: 96px;
+    }
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: 1rem;
+        margin-top: 48px;
+    }
+
+    .periodSelector {
+        align-self: flex-end;
+    }
+}
+@media (max-width: 500px) {
+    .container {
+        margin-top: 0;
+    }
+}
+
+/* For screens smaller than 1500px, make dropdown appear above */
+
+.dropupMenu {
+    top: auto;
+    bottom: calc(100% + 0.5rem);
+}
+.chvrUp {
+    display: flex;
+}
+÷ .dropdownItem {
+    width: 100%;
+    padding: 8px;
+    color: var(--text1, #f0f0f8);
+    font-size: var(--font-size-s, 12px);
+    cursor: pointer;
+}
+
+.dropdownItem:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}

--- a/packages/frontend/app/components/Pagination/Pagination.tsx
+++ b/packages/frontend/app/components/Pagination/Pagination.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from 'react';
+import styles from './Pagination.module.css';
+import { FaChevronLeft, FaChevronRight, FaChevronUp } from 'react-icons/fa';
+
+interface PaginationProps {
+    totalCount: number;
+    onPageChange: (page: number) => void;
+    rowsPerPage: number;
+    onRowsPerPageChange: (rowsPerPage: number) => void;
+    rowsOptions?: number[];
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+    totalCount,
+    onPageChange,
+    rowsPerPage,
+    rowsOptions = [10, 20, 50, 100],
+    onRowsPerPageChange,
+}) => {
+    const [rowsPerPageState, setRowsPerPageState] = useState(rowsPerPage);
+    const [page, setPage] = useState(0);
+    const [isRowsDropdownOpen, setIsRowsDropdownOpen] = useState(false);
+
+    useEffect(() => {}, [rowsPerPage]);
+
+    useEffect(() => {
+        onPageChange(page);
+    }, [page]);
+
+    useEffect(() => {
+        setPage(0);
+        onRowsPerPageChange(rowsPerPageState);
+    }, [rowsPerPageState]);
+
+    const rowsItems = useCallback(() => {
+        return rowsOptions.map((value) => (
+            <div
+                key={value}
+                className={styles.dropdownItem}
+                onClick={() => setRowsPerPageState(value)}
+            >
+                {value}
+            </div>
+        ));
+    }, []);
+
+    return (
+        <>
+            <div className={styles.paginationContainer}>
+                <div className={styles.rowsPerPage}>
+                    Rows per page:
+                    <div
+                        className={styles.rowSelector}
+                        onClick={() =>
+                            setIsRowsDropdownOpen(!isRowsDropdownOpen)
+                        }
+                    >
+                        {rowsPerPageState}
+                        <FaChevronUp className={styles.chvrUp} />
+                        {isRowsDropdownOpen && (
+                            <div className={` ${styles.dropupMenu}`}>
+                                {rowsItems()}
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <div className={styles.pageInfo}>
+                    {page * rowsPerPageState + 1}-
+                    {page * rowsPerPageState + rowsPerPageState > totalCount
+                        ? totalCount
+                        : page * rowsPerPageState + rowsPerPageState}{' '}
+                    of {totalCount}
+                </div>
+
+                <div className={styles.pageButtons}>
+                    <button
+                        className={styles.pageButton}
+                        onClick={() => {
+                            if (page > 0) {
+                                setPage(page - 1);
+                            }
+                        }}
+                        disabled={page === 0}
+                    >
+                        <FaChevronLeft size={20} />
+                    </button>
+
+                    <button
+                        className={styles.pageButton}
+                        onClick={() => {
+                            if (
+                                page < Math.floor(totalCount / rowsPerPageState)
+                            ) {
+                                setPage(page + 1);
+                            }
+                        }}
+                        disabled={
+                            page === Math.floor(totalCount / rowsPerPageState)
+                        }
+                    >
+                        <FaChevronRight size={20} />
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default Pagination;

--- a/packages/frontend/app/components/Trade/OpenOrdersTable/OpenOrdersTable.tsx
+++ b/packages/frontend/app/components/Trade/OpenOrdersTable/OpenOrdersTable.tsx
@@ -33,7 +33,7 @@ export default function OpenOrdersTable(props: OpenOrdersTableProps) {
 
     const { userSymbolOrders, userOrders } = useTradeDataStore();
 
-    const openOrdersLimit = 50;
+    const openOrdersLimit = 10;
 
     const filteredOrders = useMemo(() => {
         switch (selectedFilter) {

--- a/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.module.css
+++ b/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.module.css
@@ -217,3 +217,13 @@
         margin-right: 4px;
     }
 }
+
+.viewAllLink {
+    color: var(--accent1, #7371fc);
+    text-decoration: none;
+    font-size: var(--font-size-s, 12px);
+    grid-column: 1 / -1;
+    text-align: center;
+    padding-left: 8px;
+    margin-top: 8px;
+}

--- a/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.module.css
+++ b/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.module.css
@@ -40,7 +40,7 @@
 .tableBody {
     height: 100%;
     overflow-y: scroll;
-    padding-bottom: 1rem;
+    padding-bottom: 2rem;
 }
 .tableBody::-webkit-scrollbar {
     display: none;
@@ -226,4 +226,11 @@
     text-align: center;
     padding-left: 8px;
     margin-top: 8px;
+    position: absolute;
+    bottom: 0.2rem;
+    left: 0;
+    width: 100%;
+    background: var(--dark2);
+    text-align: left;
+    padding: 0rem 1.7rem;
 }

--- a/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.tsx
+++ b/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.tsx
@@ -1,13 +1,10 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import Pagination from '~/components/Pagination/Pagination';
+import { useTradeDataStore } from '~/stores/TradeDataStore';
+import styles from './PositionsTable.module.css';
 import PositionsTableHeader from './PositionsTableHeader';
 import PositionsTableRow from './PositionsTableRow';
-import styles from './PositionsTable.module.css';
-import { positionsData } from './data';
-import { useTradeDataStore } from '~/stores/TradeDataStore';
-import { useNavigate } from 'react-router';
-import { useDebugStore } from '~/stores/DebugStore';
-import { useCallback, useMemo, useState } from 'react';
-import { FaChevronLeft, FaChevronRight, FaChevronUp } from 'react-icons/fa';
-import Pagination from '~/components/Pagination/Pagination';
 
 interface PositionsTableProps {
     pageMode?: boolean;
@@ -57,7 +54,7 @@ export default function PositionsTable(props: PositionsTableProps) {
                     </div>
                 )}
 
-                {positions.length > 0 && !pageMode && (
+                {positions.length > limit && !pageMode && (
                     <a
                         href='#'
                         className={styles.viewAllLink}

--- a/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.tsx
+++ b/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.tsx
@@ -3,16 +3,62 @@ import PositionsTableRow from './PositionsTableRow';
 import styles from './PositionsTable.module.css';
 import { positionsData } from './data';
 import { useTradeDataStore } from '~/stores/TradeDataStore';
+import { useNavigate } from 'react-router';
+import { useDebugStore } from '~/stores/DebugStore';
+import { useCallback, useMemo, useState } from 'react';
+import { FaChevronLeft, FaChevronRight, FaChevronUp } from 'react-icons/fa';
 
-export default function PositionsTable() {
+interface PositionsTableProps {
+    pageMode?: boolean;
+}
+
+const rowsOptions = [10, 20, 50, 100];
+
+export default function PositionsTable(props: PositionsTableProps) {
+    const { pageMode } = props;
+    const navigate = useNavigate();
+
+    const { debugWallet } = useDebugStore();
+
+    const handleViewAll = () => {
+        navigate(`/positions/${debugWallet.address}`);
+    };
+
+    const [isRowsDropdownOpen, setIsRowsDropdownOpen] = useState(false);
+
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(25);
+
     const { positions } = useTradeDataStore();
     const limit = 10;
+
+    const rowsItems = useCallback(() => {
+        return rowsOptions.map((value) => (
+            <div
+                key={value}
+                className={styles.dropdownItem}
+                onClick={() => setRowsPerPage(value)}
+            >
+                {value}
+            </div>
+        ));
+    }, []);
+
+    const positionsToShow = useMemo(() => {
+        if (pageMode) {
+            return positions.slice(
+                page * rowsPerPage,
+                (page + 1) * rowsPerPage,
+            );
+        }
+        return positions.slice(0, limit);
+    }, [positions, page, rowsPerPage, pageMode]);
 
     return (
         <div className={styles.tableWrapper}>
             <PositionsTableHeader />
             <div className={styles.tableBody}>
-                {positions.slice(0, limit).map((position, index) => (
+                {positionsToShow.map((position, index) => (
                     <PositionsTableRow
                         key={`position-${index}`}
                         position={position}
@@ -26,6 +72,84 @@ export default function PositionsTable() {
                     >
                         No open positions
                     </div>
+                )}
+
+                {positions.length > 0 && !pageMode && (
+                    <a
+                        href='#'
+                        className={styles.viewAllLink}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            handleViewAll();
+                        }}
+                    >
+                        View All
+                    </a>
+                )}
+
+                {pageMode && (
+                    <>
+                        <div className={styles.paginationContainer}>
+                            <div className={styles.rowsPerPage}>
+                                Rows per page:
+                                <div
+                                    className={styles.rowSelector}
+                                    onClick={() =>
+                                        setIsRowsDropdownOpen(
+                                            !isRowsDropdownOpen,
+                                        )
+                                    }
+                                >
+                                    {rowsPerPage}
+                                    <FaChevronUp className={styles.chvrUp} />
+                                    {isRowsDropdownOpen && (
+                                        <div
+                                            className={` ${styles.dropupMenu}`}
+                                        >
+                                            {rowsItems()}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+
+                            <div className={styles.pageInfo}>
+                                {page * rowsPerPage + 1}-
+                                {(page + 1) * rowsPerPage} of {positions.length}
+                            </div>
+
+                            <div className={styles.pageButtons}>
+                                <button
+                                    className={styles.pageButton}
+                                    onClick={() => {
+                                        if (page > 0) {
+                                            setPage(page - 1);
+                                        }
+                                    }}
+                                    disabled={page === 0}
+                                >
+                                    <FaChevronLeft size={20} />
+                                </button>
+
+                                <button
+                                    className={styles.pageButton}
+                                    onClick={() => {
+                                        if (
+                                            page <
+                                            positions.length / rowsPerPage - 1
+                                        ) {
+                                            setPage(page + 1);
+                                        }
+                                    }}
+                                    disabled={
+                                        page ===
+                                        positions.length / rowsPerPage - 1
+                                    }
+                                >
+                                    <FaChevronRight size={20} />
+                                </button>
+                            </div>
+                        </div>
+                    </>
                 )}
             </div>
         </div>

--- a/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.tsx
+++ b/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.tsx
@@ -7,42 +7,25 @@ import { useNavigate } from 'react-router';
 import { useDebugStore } from '~/stores/DebugStore';
 import { useCallback, useMemo, useState } from 'react';
 import { FaChevronLeft, FaChevronRight, FaChevronUp } from 'react-icons/fa';
+import Pagination from '~/components/Pagination/Pagination';
 
 interface PositionsTableProps {
     pageMode?: boolean;
 }
 
-const rowsOptions = [10, 20, 50, 100];
-
 export default function PositionsTable(props: PositionsTableProps) {
     const { pageMode } = props;
     const navigate = useNavigate();
 
-    const { debugWallet } = useDebugStore();
-
     const handleViewAll = () => {
-        navigate(`/positions/${debugWallet.address}`);
+        navigate(`/positions`);
     };
 
-    const [isRowsDropdownOpen, setIsRowsDropdownOpen] = useState(false);
-
     const [page, setPage] = useState(0);
-    const [rowsPerPage, setRowsPerPage] = useState(25);
+    const [rowsPerPage, setRowsPerPage] = useState(20);
 
     const { positions } = useTradeDataStore();
     const limit = 10;
-
-    const rowsItems = useCallback(() => {
-        return rowsOptions.map((value) => (
-            <div
-                key={value}
-                className={styles.dropdownItem}
-                onClick={() => setRowsPerPage(value)}
-            >
-                {value}
-            </div>
-        ));
-    }, []);
 
     const positionsToShow = useMemo(() => {
         if (pageMode) {
@@ -89,66 +72,12 @@ export default function PositionsTable(props: PositionsTableProps) {
 
                 {pageMode && (
                     <>
-                        <div className={styles.paginationContainer}>
-                            <div className={styles.rowsPerPage}>
-                                Rows per page:
-                                <div
-                                    className={styles.rowSelector}
-                                    onClick={() =>
-                                        setIsRowsDropdownOpen(
-                                            !isRowsDropdownOpen,
-                                        )
-                                    }
-                                >
-                                    {rowsPerPage}
-                                    <FaChevronUp className={styles.chvrUp} />
-                                    {isRowsDropdownOpen && (
-                                        <div
-                                            className={` ${styles.dropupMenu}`}
-                                        >
-                                            {rowsItems()}
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-
-                            <div className={styles.pageInfo}>
-                                {page * rowsPerPage + 1}-
-                                {(page + 1) * rowsPerPage} of {positions.length}
-                            </div>
-
-                            <div className={styles.pageButtons}>
-                                <button
-                                    className={styles.pageButton}
-                                    onClick={() => {
-                                        if (page > 0) {
-                                            setPage(page - 1);
-                                        }
-                                    }}
-                                    disabled={page === 0}
-                                >
-                                    <FaChevronLeft size={20} />
-                                </button>
-
-                                <button
-                                    className={styles.pageButton}
-                                    onClick={() => {
-                                        if (
-                                            page <
-                                            positions.length / rowsPerPage - 1
-                                        ) {
-                                            setPage(page + 1);
-                                        }
-                                    }}
-                                    disabled={
-                                        page ===
-                                        positions.length / rowsPerPage - 1
-                                    }
-                                >
-                                    <FaChevronRight size={20} />
-                                </button>
-                            </div>
-                        </div>
+                        <Pagination
+                            totalCount={positions.length}
+                            onPageChange={setPage}
+                            rowsPerPage={rowsPerPage}
+                            onRowsPerPageChange={setRowsPerPage}
+                        />
                     </>
                 )}
             </div>

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -16,6 +16,7 @@ import './css/app.css';
 import './css/index.css';
 import { useDebugStore } from './stores/DebugStore';
 import { SdkProvider } from './hooks/useSdk';
+import WebDataConsumer from './routes/trade/webdataconsumer';
 
 // Added ComponentErrorBoundary to prevent entire app from crashing when a component fails
 class ComponentErrorBoundary extends React.Component<
@@ -102,6 +103,7 @@ export default function App() {
         <>
             <Layout>
                 <SdkProvider environment={wsEnvironment}>
+                    <WebDataConsumer />
                     <div className='root-container'>
                         {/* Added error boundary for header */}
                         <ComponentErrorBoundary>

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -14,9 +14,8 @@ import PageHeader from './components/PageHeader/PageHeader';
 import RuntimeDomManipulation from './components/Core/RuntimeDomManipulation';
 import './css/app.css';
 import './css/index.css';
-import { useDebugStore } from './stores/DebugStore';
 import { SdkProvider } from './hooks/useSdk';
-import WebDataConsumer from './routes/trade/webdataconsumer';
+import { useDebugStore } from './stores/DebugStore';
 
 // Added ComponentErrorBoundary to prevent entire app from crashing when a component fails
 class ComponentErrorBoundary extends React.Component<
@@ -103,7 +102,6 @@ export default function App() {
         <>
             <Layout>
                 <SdkProvider environment={wsEnvironment}>
-                    <WebDataConsumer />
                     <div className='root-container'>
                         {/* Added error boundary for header */}
                         <ComponentErrorBoundary>

--- a/packages/frontend/app/routes.ts
+++ b/packages/frontend/app/routes.ts
@@ -28,7 +28,7 @@ export default [
 
     route('subaccounts', 'routes/subaccounts/subaccounts.tsx'),
 
-    route('positions/:wallet?', 'routes/positions/positions.tsx'),
+    route('positions', 'routes/positions/positions.tsx'),
 
     route('*', 'routes/notFound/notFound.tsx'),
 ] satisfies RouteConfig;

--- a/packages/frontend/app/routes.ts
+++ b/packages/frontend/app/routes.ts
@@ -28,5 +28,7 @@ export default [
 
     route('subaccounts', 'routes/subaccounts/subaccounts.tsx'),
 
+    route('positions/:wallet?', 'routes/positions/positions.tsx'),
+
     route('*', 'routes/notFound/notFound.tsx'),
 ] satisfies RouteConfig;

--- a/packages/frontend/app/routes/positions/positions.module.css
+++ b/packages/frontend/app/routes/positions/positions.module.css
@@ -31,89 +31,8 @@
     gap: 8px;
 }
 
-.dropdownMenu,
-.dropupMenu {
-    position: absolute;
-    top: calc(100% + 0.5rem);
-    right: 0;
-    background-color: var(--dark3);
-    border-radius: var(--half-border-radius);
-    padding: 8px;
-    width: 100%;
-    z-index: 10;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-    text-align: right;
-}
-
-.dropdownItem {
-    width: 100%;
-    padding: 8px;
-    color: var(--text1, #f0f0f8);
-    font-size: var(--font-size-s, 12px);
-    cursor: pointer;
-}
-
-.dropdownItem:hover {
-    background-color: rgba(255, 255, 255, 0.05);
-}
-
-.paginationContainer {
-    width: 100%;
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-
-    font-size: var(--font-size-s, 12px);
-    color: var(--text1, #f0f0f8);
-    gap: 12px;
-}
-
-.rowsPerPage {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.rowSelector {
-    background-color: var(--dark2, #1a1b23);
-    padding: 8px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    position: relative;
-}
-
 .pageInfo {
     color: var(--text1, #f0f0f8);
-}
-
-.pageButtons {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.pageButton {
-    background-color: transparent;
-    border: none;
-    color: var(--text2, #6a6a6d);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.25rem;
-    border-radius: 0.25rem;
-}
-
-.pageButton:hover {
-    background-color: rgba(255, 255, 255, 0.05);
-    color: var(--text1, #f0f0f8);
-}
-
-.pageButton:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
 }
 
 .fullScreen {
@@ -172,25 +91,4 @@
     .container {
         margin-top: 0;
     }
-}
-
-/* For screens smaller than 1500px, make dropdown appear above */
-
-.dropupMenu {
-    top: auto;
-    bottom: calc(100% + 0.5rem);
-}
-.chvrUp {
-    display: flex;
-}
-÷ .dropdownItem {
-    width: 100%;
-    padding: 8px;
-    color: var(--text1, #f0f0f8);
-    font-size: var(--font-size-s, 12px);
-    cursor: pointer;
-}
-
-.dropdownItem:hover {
-    background-color: rgba(255, 255, 255, 0.05);
 }

--- a/packages/frontend/app/routes/positions/positions.module.css
+++ b/packages/frontend/app/routes/positions/positions.module.css
@@ -1,0 +1,196 @@
+.container {
+    width: 100%;
+
+    /* padding: 2rem; */
+    display: flex;
+    flex-direction: column;
+    gap: 64px;
+    margin: 0 auto;
+    margin-top: 48px;
+    overflow-x: hidden;
+}
+
+.container header {
+    color: #fff;
+
+    font-family: var(--font-family-main, 'Lexend Deca');
+    font-size: var(--font-size-xl, 36px);
+    font-style: normal;
+    font-weight: 300;
+    line-height: normal;
+}
+
+.content {
+    width: 100%;
+    border-radius: var(--main-border-radius, 16px);
+    background: var(--dark2, #111117);
+    display: flex;
+    padding: 8px 16px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.dropdownMenu,
+.dropupMenu {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    background-color: var(--dark3);
+    border-radius: var(--half-border-radius);
+    padding: 8px;
+    width: 100%;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    text-align: right;
+}
+
+.dropdownItem {
+    width: 100%;
+    padding: 8px;
+    color: var(--text1, #f0f0f8);
+    font-size: var(--font-size-s, 12px);
+    cursor: pointer;
+}
+
+.dropdownItem:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.paginationContainer {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+
+    font-size: var(--font-size-s, 12px);
+    color: var(--text1, #f0f0f8);
+    gap: 12px;
+}
+
+.rowsPerPage {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.rowSelector {
+    background-color: var(--dark2, #1a1b23);
+    padding: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    position: relative;
+}
+
+.pageInfo {
+    color: var(--text1, #f0f0f8);
+}
+
+.pageButtons {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.pageButton {
+    background-color: transparent;
+    border: none;
+    color: var(--text2, #6a6a6d);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+}
+
+.pageButton:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--text1, #f0f0f8);
+}
+
+.pageButton:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.fullScreen {
+    margin-top: 0 !important;
+    gap: 8px !important;
+}
+
+.fullScreen .searchRow {
+    height: auto;
+}
+.expandIcon {
+    fill: var(--text2);
+}
+.expandIcon:hover {
+    fill: var(--text1);
+}
+.chvrDown {
+    display: none;
+}
+.chvrUp {
+    display: none;
+}
+
+@media (min-width: 1280px) {
+    .container {
+        width: 1165px;
+    }
+}
+@media (min-width: 1580px) {
+    .container {
+        margin-top: 96px;
+    }
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: 1rem;
+        margin-top: 48px;
+    }
+
+    .searchRow {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .searchContainer {
+        width: 100%;
+        max-width: none;
+    }
+
+    .periodSelector {
+        align-self: flex-end;
+    }
+}
+@media (max-width: 500px) {
+    .container {
+        margin-top: 0;
+    }
+}
+
+/* For screens smaller than 1500px, make dropdown appear above */
+
+.dropupMenu {
+    top: auto;
+    bottom: calc(100% + 0.5rem);
+}
+.chvrUp {
+    display: flex;
+}
+÷ .dropdownItem {
+    width: 100%;
+    padding: 8px;
+    color: var(--text1, #f0f0f8);
+    font-size: var(--font-size-s, 12px);
+    cursor: pointer;
+}
+
+.dropdownItem:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}

--- a/packages/frontend/app/routes/positions/positions.tsx
+++ b/packages/frontend/app/routes/positions/positions.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import type { Route } from '../../+types/root';
+import styles from './positions.module.css';
+import PositionsTable from '~/components/Trade/PositionsTable/PositionsTable';
+
+export function meta({}: Route.MetaArgs) {
+    return [
+        { title: 'Perps - Positions' },
+        { name: 'description', content: 'Welcome to React Router!' },
+    ];
+}
+
+export function loader({ context }: Route.LoaderArgs) {
+    return { message: context.VALUE_FROM_NETLIFY };
+}
+
+function Positions({ loaderData }: Route.ComponentProps) {
+    const isFullScreen = true;
+
+    // Memoize the container class name
+    const containerClassName = useMemo(() => {
+        return `${styles.container} ${isFullScreen ? styles.fullScreen : ''}`;
+    }, [isFullScreen]);
+
+    return (
+        <div className={containerClassName}>
+            <header>Positions</header>
+
+            <div className={styles.content}>
+                <PositionsTable pageMode={true} />
+            </div>
+        </div>
+    );
+}
+export default Positions;

--- a/packages/frontend/app/routes/positions/positions.tsx
+++ b/packages/frontend/app/routes/positions/positions.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { Route } from '../../+types/root';
 import styles from './positions.module.css';
 import PositionsTable from '~/components/Trade/PositionsTable/PositionsTable';
-
+import WebDataConsumer from '../trade/webdataconsumer';
 export function meta({}: Route.MetaArgs) {
     return [
         { title: 'Perps - Positions' },
@@ -24,6 +24,7 @@ function Positions({ loaderData }: Route.ComponentProps) {
 
     return (
         <div className={containerClassName}>
+            <WebDataConsumer />
             <header>Positions</header>
 
             <div className={styles.content}>

--- a/packages/frontend/app/routes/trade.tsx
+++ b/packages/frontend/app/routes/trade.tsx
@@ -44,7 +44,7 @@ export default function Trade() {
     return (
         <>
             <TradeRouteHandler />
-            {/* <WebDataConsumer /> */}
+            <WebDataConsumer />
             {symbol && (
                 <div className={styles.container}>
                     <section

--- a/packages/frontend/app/routes/trade.tsx
+++ b/packages/frontend/app/routes/trade.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect,  useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import DepositDropdown from '~/components/PageHeader/DepositDropdown/DepositDropdown';
 import OrderInput from '~/components/Trade/OrderInput/OrderInput';
@@ -23,20 +23,17 @@ export function loader({ context }: Route.LoaderArgs) {
 }
 
 export default function Trade() {
-    const { symbol } =
-        useTradeDataStore();
+    const { symbol } = useTradeDataStore();
     const symbolRef = useRef(symbol);
     symbolRef.current = symbol;
     const { orderBookMode } = useAppSettings();
     const { marketId } = useParams<{ marketId: string }>();
     const navigate = useNavigate();
-   
 
     // useEffect(() => {
     //     const info = new Info({ environment: 'mock' });
     //     console.log({ wsManager: info.wsManager });
     // }, []);
-
 
     // logic to automatically redirect the user if they land on a
     // ... route with no token symbol in the URL
@@ -46,20 +43,17 @@ export default function Trade() {
 
     return (
         <>
-           
             <TradeRouteHandler />
-            <WebDataConsumer />
+            {/* <WebDataConsumer /> */}
             {symbol && (
-                    
-                
                 <div className={styles.container}>
                     <section
                         className={`${styles.containerTop} ${orderBookMode === 'large' ? styles.orderBookLarge : ''}`}
-                        >
+                    >
                         <div
                             className={`${styles.containerTopLeft} ${styles.symbolSectionWrapper}`}
-                            >
-                                <ComboBoxContainer/>
+                        >
+                            <ComboBoxContainer />
                             <div
                                 id='watchlistSection'
                                 className={styles.watchlist}
@@ -103,8 +97,7 @@ export default function Trade() {
                             />
                         </div>
                     </section>
-                    </div>
-                  
+                </div>
             )}
         </>
     );


### PR DESCRIPTION
Limiting positions data on positions table to 10 (in Trade Page)

- View all button has been added to show all positions in another page
- Pagination component for using in PositionsTable component
- Positions Table has been modified to use both Trade Tables and Positions Page
- `Positions.tsx` component to render table in `/positions` route