### PR TITLE
OrderBook | Order row ratio transitions

### DIFF
--- a/packages/frontend/app/routes/trade/orderbook/orderbook.module.css
+++ b/packages/frontend/app/routes/trade/orderbook/orderbook.module.css
@@ -39,7 +39,7 @@
 }
 
 .ratioBar {
-    transition: width 0.2s ease-in-out;
+    transition: width 0.3s ease-in-out;
     position: absolute;
     top: 0;
     left: 0;

--- a/packages/frontend/app/routes/trade/orderbook/orderbook.module.css
+++ b/packages/frontend/app/routes/trade/orderbook/orderbook.module.css
@@ -32,3 +32,17 @@
     padding: 0 0.5rem;
     color: var(--text3);
 }
+
+.orderRowWrapper {
+    width: 100%;
+    position: relative;
+}
+
+.ratioBar {
+    transition: width 0.2s ease-in-out;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    opacity: 0.2;
+}

--- a/packages/frontend/app/routes/trade/orderbook/orderbook.tsx
+++ b/packages/frontend/app/routes/trade/orderbook/orderbook.tsx
@@ -305,7 +305,10 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
                                 .slice(0, orderCount)
                                 .reverse()
                                 .map((order, index) => (
-                                    <div className={styles.orderRowWrapper}>
+                                    <div
+                                        key={index}
+                                        className={styles.orderRowWrapper}
+                                    >
                                         <OrderRow
                                             rowIndex={index}
                                             key={order.px}
@@ -355,7 +358,10 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
                         <div className={styles.orderBookBlock}>
                             {buys.slice(0, orderCount).map((order, index) => (
-                                <div className={styles.orderRowWrapper}>
+                                <div
+                                    key={index}
+                                    className={styles.orderRowWrapper}
+                                >
                                     <OrderRow
                                         rowIndex={index}
                                         key={order.px}

--- a/packages/frontend/app/routes/trade/orderbook/orderbook.tsx
+++ b/packages/frontend/app/routes/trade/orderbook/orderbook.tsx
@@ -19,6 +19,7 @@ import OrderRow, { OrderRowClickTypes } from './orderrow/orderrow';
 import { useSdk } from '~/hooks/useSdk';
 import { useWorker } from '~/hooks/useWorker';
 import type { OrderBookOutput } from '~/hooks/workers/orderbook.worker';
+import { useAppSettings } from '~/stores/AppSettingsStore';
 interface OrderBookProps {
     symbol: string;
     orderCount: number;
@@ -41,6 +42,8 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
     const { formatNum } = useNumFormatter();
 
     const lockOrderBook = useRef<boolean>(false);
+
+    const { getBsColor } = useAppSettings();
 
     const { buys, sells, setOrderBook } = useOrderBookStore();
     const {
@@ -302,19 +305,33 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
                                 .slice(0, orderCount)
                                 .reverse()
                                 .map((order, index) => (
-                                    <OrderRow
-                                        rowIndex={index}
-                                        key={order.px}
-                                        order={order}
-                                        coef={
-                                            selectedMode === 'symbol'
-                                                ? 1
-                                                : (symbolInfo?.markPx ?? 0)
-                                        }
-                                        resolution={filledResolution.current}
-                                        userSlots={userSellSlots}
-                                        clickListener={rowClickHandler}
-                                    />
+                                    <div className={styles.orderRowWrapper}>
+                                        <OrderRow
+                                            rowIndex={index}
+                                            key={order.px}
+                                            order={order}
+                                            coef={
+                                                selectedMode === 'symbol'
+                                                    ? 1
+                                                    : (symbolInfo?.markPx ?? 0)
+                                            }
+                                            resolution={
+                                                filledResolution.current
+                                            }
+                                            userSlots={userSellSlots}
+                                            clickListener={rowClickHandler}
+                                        />
+                                        <div
+                                            className={styles.ratioBar}
+                                            style={{
+                                                width: `${order.ratio * 100}%`,
+                                                backgroundColor:
+                                                    order.type === 'sell'
+                                                        ? getBsColor().sell
+                                                        : getBsColor().buy,
+                                            }}
+                                        ></div>
+                                    </div>
                                 ))}
                         </div>
 
@@ -338,19 +355,31 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
                         <div className={styles.orderBookBlock}>
                             {buys.slice(0, orderCount).map((order, index) => (
-                                <OrderRow
-                                    rowIndex={index}
-                                    key={order.px}
-                                    order={order}
-                                    coef={
-                                        selectedMode === 'symbol'
-                                            ? 1
-                                            : (symbolInfo?.markPx ?? 0)
-                                    }
-                                    resolution={filledResolution.current}
-                                    userSlots={userBuySlots}
-                                    clickListener={rowClickHandler}
-                                />
+                                <div className={styles.orderRowWrapper}>
+                                    <OrderRow
+                                        rowIndex={index}
+                                        key={order.px}
+                                        order={order}
+                                        coef={
+                                            selectedMode === 'symbol'
+                                                ? 1
+                                                : (symbolInfo?.markPx ?? 0)
+                                        }
+                                        resolution={filledResolution.current}
+                                        userSlots={userBuySlots}
+                                        clickListener={rowClickHandler}
+                                    />
+                                    <div
+                                        className={styles.ratioBar}
+                                        style={{
+                                            width: `${order.ratio * 100}%`,
+                                            backgroundColor:
+                                                order.type === 'buy'
+                                                    ? getBsColor().buy
+                                                    : getBsColor().sell,
+                                        }}
+                                    ></div>
+                                </div>
                             ))}
                         </div>
                     </>

--- a/packages/frontend/app/routes/trade/orderbook/orderrow/orderrow.tsx
+++ b/packages/frontend/app/routes/trade/orderbook/orderrow/orderrow.tsx
@@ -57,16 +57,6 @@ const OrderRow: React.FC<OrderRowProps> = ({
             className={`${styles.orderRow} ${userSlots.has(formattedPrice) ? styles.userOrder : ''}`}
             onClick={handleClick}
         >
-            {/* <div
-                className={styles.ratio}
-                style={{
-                    width: `${order.ratio * 100}%`,
-                    backgroundColor:
-                        order.type === 'buy'
-                            ? getBsColor().buy
-                            : getBsColor().sell,
-                }}
-            ></div> */}
             {userSlots.has(formattedPrice) && (
                 <div className={styles.userOrderIndicator}></div>
             )}

--- a/packages/frontend/app/routes/trade/orderbook/orderrow/orderrow.tsx
+++ b/packages/frontend/app/routes/trade/orderbook/orderrow/orderrow.tsx
@@ -57,7 +57,7 @@ const OrderRow: React.FC<OrderRowProps> = ({
             className={`${styles.orderRow} ${userSlots.has(formattedPrice) ? styles.userOrder : ''}`}
             onClick={handleClick}
         >
-            <div
+            {/* <div
                 className={styles.ratio}
                 style={{
                     width: `${order.ratio * 100}%`,
@@ -66,7 +66,7 @@ const OrderRow: React.FC<OrderRowProps> = ({
                             ? getBsColor().buy
                             : getBsColor().sell,
                 }}
-            ></div>
+            ></div> */}
             {userSlots.has(formattedPrice) && (
                 <div className={styles.userOrderIndicator}></div>
             )}


### PR DESCRIPTION
Transition has been added for OrderRows in OrderBook
Ratio component has been moved into wrapper component to not effect by re-render once related row has been updated
Div hierarchy has been changed in OrderBook, and transition has been added into ratio div