### PR TITLE
Trade Tables | Hiding some tabs on Trade Page

### DIFF
--- a/packages/frontend/app/components/Tabs/Tabs.tsx
+++ b/packages/frontend/app/components/Tabs/Tabs.tsx
@@ -113,6 +113,10 @@ export default function Tabs(props: TabsProps) {
     const defaultTabId = defaultTab || getTabId(tabs[0]);
     const [activeTab, setActiveTab] = useState<string>(defaultTabId);
 
+    useEffect(() => {
+        setActiveTab(defaultTabId);
+    }, [defaultTabId]);
+
     const tabsListRef = useRef<HTMLDivElement>(null);
     const tabsWrapperRef = useRef<HTMLDivElement>(null);
 

--- a/packages/frontend/app/components/Trade/TradeTables/TradeTables.tsx
+++ b/packages/frontend/app/components/Trade/TradeTables/TradeTables.tsx
@@ -67,7 +67,7 @@ export default function TradeTable() {
     useEffect(() => {
         if (page === Pages.TRADE) {
             if (tradePageBlackListTabs.has(selectedTradeTab)) {
-                handleTabChange('Balances');
+                handleTabChange('Positions');
             }
         }
     }, [page]);

--- a/packages/frontend/app/hooks/usePage.ts
+++ b/packages/frontend/app/hooks/usePage.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { useIsClient } from './useIsClient';
+
+export enum Pages {
+    TRADE = 'trade',
+    PORTFOLIO = 'portfolio',
+}
+
+/**
+ * Custom Hook to check if the component is mounted on the client side
+ */
+export function usePage() {
+    const isClient = useIsClient();
+
+    const [page, setPage] = useState<Pages>();
+
+    useEffect(() => {
+        if (isClient) {
+            const path = window.location.pathname;
+            if (path.split('/').length > 1) {
+                const page = path.split('/')[1];
+                if (page === Pages.TRADE) {
+                    setPage(Pages.TRADE);
+                } else if (page === Pages.PORTFOLIO) {
+                    setPage(Pages.PORTFOLIO);
+                }
+            }
+        }
+    }, [isClient]);
+
+    return { page };
+}


### PR DESCRIPTION
`Funding History` and `Deposits and Withdrawals` tabs are hidden on Trade Page

Changes;

- usePage hook has been created to track current page (trade and portfolio types have been added for now)
- Using page hook on TradeTables component to hide tabs on Trade Page
- Fix on Tabs component to select 'Balances' tab if last selected tab is not rendered in Trade Page (needed to add a useEffect to Tabs component)