### PR TITLE
Consolidate Font Family Usage Across the App

### DIFF
--- a/packages/frontend/app/components/AppOptions/AppOptions.module.css
+++ b/packages/frontend/app/components/AppOptions/AppOptions.module.css
@@ -6,7 +6,6 @@
     gap: 8px;
     min-width: 400px;
     user-select: none;
-    font-family: var(--font-family-main);
     background-color: var(--dark3);
     border-radius: 20px;
 

--- a/packages/frontend/app/components/Button/Button.module.css
+++ b/packages/frontend/app/components/Button/Button.module.css
@@ -8,7 +8,6 @@
     align-items: center;
     flex-direction: column;
     border-radius: var(--half-border-radius, 8px);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-style: normal;
     font-weight: 400;
     line-height: normal;

--- a/packages/frontend/app/components/Inputs/ComboBox/ComboBox.module.css
+++ b/packages/frontend/app/components/Inputs/ComboBox/ComboBox.module.css
@@ -78,7 +78,6 @@
     user-select: none;
     font-size: var(--font-size-s);
     z-index: 2;
-    font-family: var(--font-family-main);
     background-color: var(--dark2);
     border-radius: 4px;
 

--- a/packages/frontend/app/components/Links/Links.module.css
+++ b/packages/frontend/app/components/Links/Links.module.css
@@ -13,7 +13,6 @@
 }
 
 .title {
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-l, 24px);
     margin-bottom: 20px;
 }
@@ -43,14 +42,12 @@
     align-items: center;
     gap: 16px;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-fize-l, 24px);
     font-weight: 400;
 }
 
 .description {
     color: var(--text2, #6a6a6d);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
 }
@@ -64,7 +61,6 @@
     border-radius: var(--half-border-radius, 8px);
     background: var(--accent1, #7371fc);
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
     text-decoration: none;

--- a/packages/frontend/app/components/MobileFooter/MobileFooter.module.css
+++ b/packages/frontend/app/components/MobileFooter/MobileFooter.module.css
@@ -1,0 +1,74 @@
+.footer {
+    display: flex;
+    height: 56px;
+    padding: 0 8px;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    z-index: 100;
+    background: var(--dark2, #111117);
+
+    border-radius: var(--main-border-radius, 16px)
+        var(--main-border-radius, 16px) 0 0;
+}
+
+.navItem {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    height: 100%;
+}
+
+.iconWrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    width: 100%;
+    height: 100%;
+}
+
+.icon {
+    color: var(--text1, #f0f0f8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.label {
+    color: var(--text1, #f0f0f8);
+    text-align: center;
+    font-size: var(--font-size-s, 12px);
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+}
+
+.navItem:hover .icon,
+.navItem:hover .label,
+.navItem:active .icon,
+.navItem:active .label {
+    color: var(--base-accent1, #7371fc);
+}
+
+/* For devices that support hover */
+@media (hover: hover) {
+    .navItem:hover .icon,
+    .navItem:hover .label {
+        color: var(--accent1, #7371fc);
+    }
+}
+
+/* Active state for navigation items */
+.navItem[aria-current='page'] .icon,
+.navItem[aria-current='page'] .label {
+    color: var(--accent1, #7371fc);
+}

--- a/packages/frontend/app/components/Notifications/Notification.module.css
+++ b/packages/frontend/app/components/Notifications/Notification.module.css
@@ -7,7 +7,6 @@
     width: 380px;
     height: 90px;
     padding: 16px;
-    font-family: var(--font-family-main);
     background-color: var(--dark3);
     border-radius: 16px;
     user-select: none;

--- a/packages/frontend/app/components/PageHeader/DepositDropdown/DepositDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/DepositDropdown/DepositDropdown.module.css
@@ -50,8 +50,6 @@
 
     color: var(--text1, #f0f0f8);
 
-    /* Main/M */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -74,7 +72,6 @@
 
     color: var(--text1, #f0f0f8);
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -90,7 +87,6 @@
     color: var(--text1, #f0f0f8);
     text-align: center;
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -111,8 +107,6 @@
     flex: 1 0 0;
     color: var(--text1, #f0f0f8);
 
-    /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -131,8 +125,6 @@
     color: var(--text2, #6a6a6d);
     text-align: center;
 
-    /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -150,8 +142,6 @@
     color: var(--text1, #f0f0f8);
     text-align: center;
 
-    /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/PageHeader/DropdownMenu/DropdownMenu.module.css
+++ b/packages/frontend/app/components/PageHeader/DropdownMenu/DropdownMenu.module.css
@@ -28,7 +28,6 @@
     align-self: stretch;
     border-radius: var(--half-border-radius, 8px);
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -43,7 +42,6 @@
 
 .version {
     color: var(--text2, #6a6a6d);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -68,7 +66,6 @@
 
     color: var(--text1, #f0f0f8);
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/PageHeader/MoreDropdown/MoreDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/MoreDropdown/MoreDropdown.module.css
@@ -33,8 +33,6 @@
 .container a {
     color: var(--text2, #6a6a6d);
 
-    /* Main/M */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/PageHeader/NetworkDropdown/NetworkDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/NetworkDropdown/NetworkDropdown.module.css
@@ -43,8 +43,6 @@
 .testnet {
     color: var(--core-accent1, #7371fc);
 
-    /* Main/XS */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xs, 10px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/PageHeader/PageHeader.module.css
+++ b/packages/frontend/app/components/PageHeader/PageHeader.module.css
@@ -23,7 +23,6 @@
 .moreButton {
     color: var(--text2, #6a6a6d);
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -145,7 +144,6 @@
     background: var(--dark2, #0e0e14);
     color: var(--accent1, #7371fc);
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -171,7 +169,6 @@
     color: var(--text1, #f0f0f8);
 
     /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/PageHeader/RpcDropdown/RpcDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/RpcDropdown/RpcDropdown.module.css
@@ -30,8 +30,6 @@
     color: var(--accent1, #7371fc);
     text-align: center;
 
-    /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -50,8 +48,6 @@
 .rpcRowContainer p {
     color: var(--text1, #f0f0f8);
 
-    /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -61,7 +57,6 @@
     color: var(--text2, #6a6a6d);
 
     /* Main/S */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/PageHeader/WalletDropdown/WalletDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/WalletDropdown/WalletDropdown.module.css
@@ -50,7 +50,6 @@
     border-radius: var(--half-border-radius, 8px);
     background: var(--dark3, #0e0e14);
     color: var(--accent1, #7371fc);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -89,7 +88,6 @@
     gap: var(--main-border-radius);
     color: var(--text1, #f0f0f8);
     text-align: center;
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -123,7 +121,6 @@
     cursor: pointer;
 
     /* Main/M */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -132,7 +129,6 @@
     color: var(--text1, #f0f0f8);
 
     /* Main/M */
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -154,7 +150,6 @@
     align-items: center;
     color: var(--text2, #6a6a6d);
     text-align: center;
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-font, 12px);
     font-style: normal;
     font-weight: 400;
@@ -203,7 +198,6 @@
 
 .tokenDisplayName {
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -222,7 +216,6 @@
 .tokenDisplayRight h3 {
     color: var(--text1, #f0f0f8);
     text-align: right;
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     font-style: normal;
     font-weight: 400;
@@ -232,7 +225,6 @@
 .tokenDisplayRight p {
     color: var(--text2, #6a6a6d);
     text-align: right;
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/Pagination/Pagination.module.css
+++ b/packages/frontend/app/components/Pagination/Pagination.module.css
@@ -88,7 +88,6 @@
     color: var(--text2, #bcbcc4);
     text-align: center;
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/Portfolio/PerformancePanel/PerformancePanel.module.css
+++ b/packages/frontend/app/components/Portfolio/PerformancePanel/PerformancePanel.module.css
@@ -28,7 +28,6 @@
     flex-direction: column;
     gap: 8px;
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/Portfolio/PortfolioDeposit/PortfolioDeposit.module.css
+++ b/packages/frontend/app/components/Portfolio/PortfolioDeposit/PortfolioDeposit.module.css
@@ -22,7 +22,6 @@
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -76,7 +75,6 @@
     border: none;
     background: transparent;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
 }
 
@@ -152,8 +150,6 @@
     border: none;
 
     cursor: pointer;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     color: var(--text1, #f0f0f8);
 }

--- a/packages/frontend/app/components/Portfolio/PortfolioSend/PortfolioSend.module.css
+++ b/packages/frontend/app/components/Portfolio/PortfolioSend/PortfolioSend.module.css
@@ -17,7 +17,6 @@
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -48,7 +47,6 @@
     border: none;
     background: transparent;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
 }
 

--- a/packages/frontend/app/components/Portfolio/PortfolioWithdraw/PortfolioWithdraw.module.css
+++ b/packages/frontend/app/components/Portfolio/PortfolioWithdraw/PortfolioWithdraw.module.css
@@ -28,7 +28,6 @@
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -61,7 +60,6 @@
     border: none;
     background: transparent;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
 }
 
@@ -138,7 +136,6 @@
 
     cursor: pointer;
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     color: var(--text1, #f0f0f8);
 }

--- a/packages/frontend/app/components/Referrals/CodeTabs/CodeTabs.module.css
+++ b/packages/frontend/app/components/Referrals/CodeTabs/CodeTabs.module.css
@@ -55,7 +55,6 @@
     color: var(--base-text1, #f0f0f8);
     text-align: center;
 
-    font-family: var(--Font-Family-Main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -82,7 +81,6 @@
     flex-direction: column;
 
     gap: 16px;
-    font-family: var(--Font-Family-Main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;
@@ -107,7 +105,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    font-family: var(--Font-Family-Main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/ShareModal/ShareModal.module.css
+++ b/packages/frontend/app/components/ShareModal/ShareModal.module.css
@@ -4,7 +4,6 @@
     max-width: 1200px;
     padding: 0 24px;
     gap: 24px;
-    font-family: var(--font-family-main);
     background-color: var(--dark3);
 }
 

--- a/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
+++ b/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
@@ -122,9 +122,6 @@
 }
 .statusCell {
 }
-.orderIdCell {
-    font-family: monospace;
-}
 
 @media (max-width: 1400px) {
     .rowContainer,

--- a/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.module.css
@@ -7,7 +7,6 @@
 .containerTitle {
     color: var(--text2, #bcbcc4);
 
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/Trade/OrderInput/OrderDropdown/OrderDropdown.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderDropdown/OrderDropdown.module.css
@@ -15,7 +15,6 @@
     border-radius: 8px;
     border: none;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lato', sans-serif);
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
     line-height: normal;
@@ -68,7 +67,6 @@
     align-items: center;
     cursor: pointer;
     color: var(--text2, #bcbcc4);
-    font-family: var(--font-family-main, 'Lato', sans-serif);
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
     transition: background-color 0.15s ease;
@@ -88,7 +86,6 @@
     padding: 8px;
     text-align: center;
     color: var(---text2, #bcbcc4);
-    font-family: var(--Font-Family-Main, 'Lato', sans-serif);
     font-size: var(--Font-Size-Font-S, 12px);
     font-style: italic;
 }

--- a/packages/frontend/app/components/Trade/OrderInput/OrderInput.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderInput.module.css
@@ -77,7 +77,6 @@
     border-radius: 8px;
     border: none;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lato', sans-serif);
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
     line-height: normal;

--- a/packages/frontend/app/components/Trade/OrderInput/PositionSIze/PositionSize.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/PositionSIze/PositionSize.module.css
@@ -8,8 +8,6 @@
 }
 .containerTitle {
     color: var(--text2, #bcbcc4);
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/Trade/OrderInput/ScaleOrders/ScaleOrders.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/ScaleOrders/ScaleOrders.module.css
@@ -265,8 +265,6 @@
 
 .errorMessage {
     color: var(--red, #ef5350);
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/components/Vault/DepositModal/DepositModal.module.css
+++ b/packages/frontend/app/components/Vault/DepositModal/DepositModal.module.css
@@ -28,7 +28,6 @@
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -82,7 +81,6 @@
     border: none;
     background: transparent;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
 }
 
@@ -158,8 +156,6 @@
     border: none;
 
     cursor: pointer;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-m, 18px);
     color: var(--text1, #f0f0f8);
 }

--- a/packages/frontend/app/components/Vault/VaultCard/VaultCard.module.css
+++ b/packages/frontend/app/components/Vault/VaultCard/VaultCard.module.css
@@ -32,7 +32,6 @@
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .headerTextContainer h3 {
     color: var(--text1, #f0f0f8);
@@ -69,8 +68,6 @@
     gap: auto;
 }
 .detailsItem {
-    font-family: var(--font-family-main, 'Lexend Deca');
-
     display: flex;
     flex-direction: column;
     gap: 4px;

--- a/packages/frontend/app/components/Vault/VaultRow/VaultRow.module.css
+++ b/packages/frontend/app/components/Vault/VaultRow/VaultRow.module.css
@@ -6,7 +6,6 @@
 
     padding-right: 8px;
     align-items: center;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .cell {
     font-size: var(--font-size-m, 18px);

--- a/packages/frontend/app/components/Vault/WithdrawModal/WithdrawModal.module.css
+++ b/packages/frontend/app/components/Vault/WithdrawModal/WithdrawModal.module.css
@@ -16,7 +16,6 @@
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-    font-family: var(--font-family-main, 'Lexend Deca');
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -47,7 +46,6 @@
     border: none;
     background: transparent;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
 }
 

--- a/packages/frontend/app/css/index.css
+++ b/packages/frontend/app/css/index.css
@@ -102,7 +102,7 @@ html {
 }
 
 body {
-    font-family: var(--font-sans, sans-serif);
+    font-family: var(--font-family-main, 'Lexend Deca');
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/packages/frontend/app/routes/leaderboard/leaderboard.module.css
+++ b/packages/frontend/app/routes/leaderboard/leaderboard.module.css
@@ -12,8 +12,6 @@
 
 .container header {
     color: #fff;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;
@@ -184,8 +182,6 @@
 .footer {
     color: var(--text2, #bcbcc4);
     text-align: center;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-style: normal;
     font-weight: 400;

--- a/packages/frontend/app/routes/more/more.module.css
+++ b/packages/frontend/app/routes/more/more.module.css
@@ -16,10 +16,7 @@
 }
 
 .title {
-    font-family: var(--font-family-main, 'Lexend Deca');
-
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-xxl, 64px);
     font-style: normal;
     font-weight: 300;
@@ -51,14 +48,12 @@
     align-items: center;
     gap: 16px;
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-fize-l, 24px);
     font-weight: 400;
 }
 
 .description {
     color: var(--text2, #6a6a6d);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
 }
@@ -72,7 +67,6 @@
     border-radius: var(--half-border-radius, 8px);
     background: var(--accent1, #7371fc);
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-s, 12px);
     font-weight: 400;
     text-decoration: none;

--- a/packages/frontend/app/routes/orderHistory/orderHistory.module.css
+++ b/packages/frontend/app/routes/orderHistory/orderHistory.module.css
@@ -12,8 +12,6 @@
 
 .container header {
     color: #fff;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;

--- a/packages/frontend/app/routes/portfolio/portfolio.module.css
+++ b/packages/frontend/app/routes/portfolio/portfolio.module.css
@@ -11,7 +11,6 @@
 }
 .container header {
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;
@@ -27,7 +26,6 @@
     height: 100%;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-style: normal;
     font-weight: 400;
     line-height: normal;
@@ -125,7 +123,6 @@
     min-width: 500px;
     padding: 8px 16px 16px;
     border-radius: var(--main-border-radius);
-    font-family: var(--font-family-main);
     color: var(--text1);
     gap: 16px;
     background-color: var(--dark3);

--- a/packages/frontend/app/routes/positions/positions.module.css
+++ b/packages/frontend/app/routes/positions/positions.module.css
@@ -12,8 +12,6 @@
 
 .container header {
     color: #fff;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;

--- a/packages/frontend/app/routes/referrals/referrals.module.css
+++ b/packages/frontend/app/routes/referrals/referrals.module.css
@@ -13,7 +13,6 @@
 
 .container header {
     color: var(--text1, #f0f0f8);
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;
@@ -37,7 +36,6 @@
     flex-direction: row;
     align-items: center;
     gap: 5rem;
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-style: normal;
     font-weight: 400;
     line-height: normal;

--- a/packages/frontend/app/routes/subaccounts/subaccounts.module.css
+++ b/packages/frontend/app/routes/subaccounts/subaccounts.module.css
@@ -5,7 +5,6 @@
     padding-top: 5vh;
     height: 100%;
     width: 100%;
-    font-family: var(--font-family-main);
 }
 
 .subaccounts_wrapper {

--- a/packages/frontend/app/routes/trade/orderbook/orderbooksection.module.css
+++ b/packages/frontend/app/routes/trade/orderbook/orderbooksection.module.css
@@ -5,7 +5,6 @@
     justify-content: center;
     width: 100%;
     font-size: 0.8rem;
-    font-family: var(--font-family-main);
 }
 
 .orderBookSectionContainer {

--- a/packages/frontend/app/routes/trade/symbol/symbolinfo.module.css
+++ b/packages/frontend/app/routes/trade/symbol/symbolinfo.module.css
@@ -1,6 +1,5 @@
 .symbolInfoContainer {
     width: 100%;
-    font-family: var(--font-family-main);
     font-size: 0.8rem;
     display: flex;
     flex-direction: row;

--- a/packages/frontend/app/routes/trade/watchlist/watchlist.module.css
+++ b/packages/frontend/app/routes/trade/watchlist/watchlist.module.css
@@ -11,7 +11,6 @@
     display: flex;
     padding-left: 2rem;
     align-items: center;
-    font-family: var(--font-family-main);
     animation: fadeIn 0.1s ease;
     white-space: nowrap;
 }

--- a/packages/frontend/app/routes/tradeHistory/tradeHistory.module.css
+++ b/packages/frontend/app/routes/tradeHistory/tradeHistory.module.css
@@ -12,8 +12,6 @@
 
 .container header {
     color: #fff;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;

--- a/packages/frontend/app/routes/twapFillHistory/twapFillHistory.module.css
+++ b/packages/frontend/app/routes/twapFillHistory/twapFillHistory.module.css
@@ -12,8 +12,6 @@
 
 .container header {
     color: #fff;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;

--- a/packages/frontend/app/routes/twapHistory/twapHistory.module.css
+++ b/packages/frontend/app/routes/twapHistory/twapHistory.module.css
@@ -12,8 +12,6 @@
 
 .container header {
     color: #fff;
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;

--- a/packages/frontend/app/routes/vaults/vaults.module.css
+++ b/packages/frontend/app/routes/vaults/vaults.module.css
@@ -1,5 +1,4 @@
 .container {
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-style: normal;
     line-height: normal;
     background-color: transparent;

--- a/packages/frontend/app/routes/vaults/vaultsNew.module.css
+++ b/packages/frontend/app/routes/vaults/vaultsNew.module.css
@@ -14,8 +14,6 @@
     align-items: center;
     gap: 16px;
     color: var(--text1, #e1eeee);
-
-    font-family: var(--font-family-main, 'Lexend Deca');
     font-size: var(--font-size-xl, 36px);
     font-style: normal;
     font-weight: 300;


### PR DESCRIPTION
## 🧹 Consolidate Font Family Usage Across the App

This PR standardizes font usage across the entire application by defining a single `font-family` in `index.css` and applying it globally via the `body` selector.

---

### ✅ What’s Changed

- Defined a **single font family** in `index.css` under the `body` selector.
- Removed **all other instances** of `font-family` across all stylesheets and component-level CSS files.

---

### 🎯 Result

- The app now uses **only one font family**, applied globally.
- It is defined **exclusively in `index.css`** via the `body` tag.
- Ensures a **consistent and maintainable typography system** throughout the codebase.


