### PR TITLE
Consolidate Font Weight, Font Style, and Line Height Usage

### DIFF
--- a/packages/frontend/app/components/Button/Button.module.css
+++ b/packages/frontend/app/components/Button/Button.module.css
@@ -8,9 +8,6 @@
     align-items: center;
     flex-direction: column;
     border-radius: var(--half-border-radius, 8px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     border: none;
     cursor: pointer;
 }

--- a/packages/frontend/app/components/Leaderboard/LeaderboardTable/LeaderboardTable.module.css
+++ b/packages/frontend/app/components/Leaderboard/LeaderboardTable/LeaderboardTable.module.css
@@ -66,7 +66,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -75,7 +74,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Links/Links.module.css
+++ b/packages/frontend/app/components/Links/Links.module.css
@@ -43,13 +43,11 @@
     gap: 16px;
     color: var(--text1, #f0f0f8);
     font-size: var(--font-fize-l, 24px);
-    font-weight: 400;
 }
 
 .description {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
 }
 
 .button {
@@ -62,7 +60,6 @@
     background: var(--accent1, #7371fc);
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     text-decoration: none;
 }
 

--- a/packages/frontend/app/components/MobileFooter/MobileFooter.module.css
+++ b/packages/frontend/app/components/MobileFooter/MobileFooter.module.css
@@ -47,9 +47,6 @@
     color: var(--text1, #f0f0f8);
     text-align: center;
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .navItem:hover .icon,

--- a/packages/frontend/app/components/PageHeader/DepositDropdown/DepositDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/DepositDropdown/DepositDropdown.module.css
@@ -47,13 +47,8 @@
 
     border-radius: var(--half-border-radius, 8px);
     background: var(--accent1, #7371fc);
-
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .actionButtons button {
     outline: none;
@@ -69,13 +64,8 @@
 
     border-radius: var(--half-border-radius, 8px);
     background: var(--dark3, #16161c);
-
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .notConnectedContainer {
@@ -86,11 +76,7 @@
 .notConnectedText {
     color: var(--text1, #f0f0f8);
     text-align: center;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .overviewContainer {
     display: flex;
@@ -106,11 +92,7 @@
 .overviewContainer h3 {
     flex: 1 0 0;
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .overviewItem {
@@ -124,11 +106,7 @@
 .overviewLabel {
     color: var(--text2, #6a6a6d);
     text-align: center;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .tooltipContainer {
@@ -141,9 +119,5 @@
 .value {
     color: var(--text1, #f0f0f8);
     text-align: center;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }

--- a/packages/frontend/app/components/PageHeader/DropdownMenu/DropdownMenu.module.css
+++ b/packages/frontend/app/components/PageHeader/DropdownMenu/DropdownMenu.module.css
@@ -29,9 +29,6 @@
     border-radius: var(--half-border-radius, 8px);
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     cursor: pointer;
     transition: all var(--ease-in-out-med);
     user-select: none;
@@ -43,9 +40,6 @@
 .version {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     margin-top: 8px;
     height: 19px;
 }
@@ -60,16 +54,10 @@
     justify-content: center;
     align-items: center;
     align-self: stretch;
-
     border-radius: var(--half-border-radius, 8px);
     background: var(--accent1, #7371fc);
-
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .logoutButton:hover {

--- a/packages/frontend/app/components/PageHeader/MoreDropdown/MoreDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/MoreDropdown/MoreDropdown.module.css
@@ -32,11 +32,7 @@
 
 .container a {
     color: var(--text2, #6a6a6d);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .row {

--- a/packages/frontend/app/components/PageHeader/NetworkDropdown/NetworkDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/NetworkDropdown/NetworkDropdown.module.css
@@ -42,9 +42,5 @@
 }
 .testnet {
     color: var(--core-accent1, #7371fc);
-
     font-size: var(--font-size-xs, 10px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }

--- a/packages/frontend/app/components/PageHeader/PageHeader.module.css
+++ b/packages/frontend/app/components/PageHeader/PageHeader.module.css
@@ -22,11 +22,7 @@
 .container nav a,
 .moreButton {
     color: var(--text2, #6a6a6d);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .moreButton {
@@ -143,11 +139,7 @@
     border-radius: var(--half-border-radius, 8px);
     background: var(--dark2, #0e0e14);
     color: var(--accent1, #7371fc);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .walletButton:hover {
@@ -170,9 +162,6 @@
 
     /* Main/S */
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .networkButton {

--- a/packages/frontend/app/components/PageHeader/RpcDropdown/RpcDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/RpcDropdown/RpcDropdown.module.css
@@ -29,11 +29,7 @@
 .viewMoreButton {
     color: var(--accent1, #7371fc);
     text-align: center;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .container section {
     gap: 5px;
@@ -47,18 +43,10 @@
 
 .rpcRowContainer p {
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .container h3 {
     color: var(--text2, #6a6a6d);
-
     /* Main/S */
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }

--- a/packages/frontend/app/components/PageHeader/WalletDropdown/WalletDropdown.module.css
+++ b/packages/frontend/app/components/PageHeader/WalletDropdown/WalletDropdown.module.css
@@ -51,9 +51,6 @@
     background: var(--dark3, #0e0e14);
     color: var(--accent1, #7371fc);
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .walletButton:hover {
@@ -89,9 +86,6 @@
     color: var(--text1, #f0f0f8);
     text-align: center;
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .profileRightTop svg {
@@ -121,18 +115,8 @@
     cursor: pointer;
 
     /* Main/M */
-    font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
-
     color: var(--text1, #f0f0f8);
-
-    /* Main/M */
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .accountButton {
@@ -151,9 +135,6 @@
     color: var(--text2, #6a6a6d);
     text-align: center;
     font-size: var(--font-size-font, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .tokensContainer {
@@ -199,9 +180,6 @@
 .tokenDisplayName {
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     flex: 1 1 0;
 }
 
@@ -217,16 +195,10 @@
     color: var(--text1, #f0f0f8);
     text-align: right;
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .tokenDisplayRight p {
     color: var(--text2, #6a6a6d);
     text-align: right;
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }

--- a/packages/frontend/app/components/Pagination/Pagination.module.css
+++ b/packages/frontend/app/components/Pagination/Pagination.module.css
@@ -87,11 +87,7 @@
 .footer {
     color: var(--text2, #bcbcc4);
     text-align: center;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     align-self: stretch;
 }
 .periodSelectorContainer {

--- a/packages/frontend/app/components/Portfolio/PerformancePanel/PerformancePanel.module.css
+++ b/packages/frontend/app/components/Portfolio/PerformancePanel/PerformancePanel.module.css
@@ -27,11 +27,7 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .perfChart {

--- a/packages/frontend/app/components/Portfolio/PortfolioDeposit/PortfolioDeposit.module.css
+++ b/packages/frontend/app/components/Portfolio/PortfolioDeposit/PortfolioDeposit.module.css
@@ -19,9 +19,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -106,9 +103,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     padding: 8px;
     border-radius: var(--half-border-radius, 8px);
     border: 1px solid var(--dark4, #27272c);

--- a/packages/frontend/app/components/Portfolio/PortfolioSend/PortfolioSend.module.css
+++ b/packages/frontend/app/components/Portfolio/PortfolioSend/PortfolioSend.module.css
@@ -14,9 +14,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -86,9 +83,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     padding: 8px;
     border-radius: var(--half-border-radius, 8px);
     border: 1px solid var(--dark4, #27272c);

--- a/packages/frontend/app/components/Portfolio/PortfolioWithdraw/PortfolioWithdraw.module.css
+++ b/packages/frontend/app/components/Portfolio/PortfolioWithdraw/PortfolioWithdraw.module.css
@@ -25,9 +25,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -91,9 +88,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     padding: 8px;
     border-radius: var(--half-border-radius, 8px);
     border: 1px solid var(--dark4, #27272c);

--- a/packages/frontend/app/components/Referrals/CodeTabs/CodeTabs.module.css
+++ b/packages/frontend/app/components/Referrals/CodeTabs/CodeTabs.module.css
@@ -54,11 +54,7 @@
 .enterCodeContent h6 {
     color: var(--base-text1, #f0f0f8);
     text-align: center;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .enterCodeContent input {
     display: flex;
@@ -79,12 +75,8 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-
     gap: 16px;
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .createCodeContent .walletLink {
     display: flex;
@@ -106,7 +98,4 @@
     justify-content: center;
     align-items: center;
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }

--- a/packages/frontend/app/components/Referrals/ReferralsTable/ReferralsTable.module.css
+++ b/packages/frontend/app/components/Referrals/ReferralsTable/ReferralsTable.module.css
@@ -43,7 +43,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -52,7 +51,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Tables/GenericTable/GenericTable.module.css
+++ b/packages/frontend/app/components/Tables/GenericTable/GenericTable.module.css
@@ -52,7 +52,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -61,7 +60,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Tabs/Tabs.module.css
+++ b/packages/frontend/app/components/Tabs/Tabs.module.css
@@ -38,7 +38,6 @@
     border: none;
     cursor: pointer;
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     color: var(--text2);
     position: relative;
     transition: color 0.2s ease;

--- a/packages/frontend/app/components/TokenDropdown/TokenDropdown.module.css
+++ b/packages/frontend/app/components/TokenDropdown/TokenDropdown.module.css
@@ -34,7 +34,6 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    font-weight: 400;
 }
 
 .dropdown {
@@ -96,7 +95,6 @@
 }
 
 .tokenSymbol {
-    font-weight: 500;
     font-size: 15px;
 }
 

--- a/packages/frontend/app/components/Trade/BalancesTable/BalancesTable.module.css
+++ b/packages/frontend/app/components/Trade/BalancesTable/BalancesTable.module.css
@@ -47,7 +47,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -56,8 +55,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/DepositsWithdrawalsTable/DepositsWithdrawalsTable.module.css
+++ b/packages/frontend/app/components/Trade/DepositsWithdrawalsTable/DepositsWithdrawalsTable.module.css
@@ -69,7 +69,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -78,7 +77,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/FundingHistoryTable/FundingHistoryTable.module.css
+++ b/packages/frontend/app/components/Trade/FundingHistoryTable/FundingHistoryTable.module.css
@@ -47,7 +47,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -56,7 +55,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/OpenOrdersTable/OpenOrdersTable.module.css
+++ b/packages/frontend/app/components/Trade/OpenOrdersTable/OpenOrdersTable.module.css
@@ -47,7 +47,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -56,7 +55,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
+++ b/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
@@ -47,7 +47,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -56,7 +55,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/OrderInput/ChasePrice/ChasePrice.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/ChasePrice/ChasePrice.module.css
@@ -6,9 +6,5 @@
 }
 .chasePriceContainer h3 {
     color: var(--text2, #bcbcc4);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }

--- a/packages/frontend/app/components/Trade/OrderInput/ConfirmationModal/ConfirmationModal.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/ConfirmationModal/ConfirmationModal.module.css
@@ -14,10 +14,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .infoRow {

--- a/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.module.css
@@ -6,11 +6,7 @@
 }
 .containerTitle {
     color: var(--text2, #bcbcc4);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .sliderWithValue {
@@ -128,7 +124,6 @@
     border: none;
     color: var(--text1);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     text-align: center;
     outline: none;
 }

--- a/packages/frontend/app/components/Trade/OrderInput/MarginModal/MarginModal.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/MarginModal/MarginModal.module.css
@@ -43,11 +43,7 @@
     align-self: stretch;
     color: var(--text2, #bcbcc4);
     cursor: pointer;
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     transition: all var(--ease-in-out-med);
     text-align: start;
 }

--- a/packages/frontend/app/components/Trade/OrderInput/OrderDropdown/OrderDropdown.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderDropdown/OrderDropdown.module.css
@@ -16,8 +16,6 @@
     border: none;
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
-    line-height: normal;
     cursor: pointer;
     flex-shrink: 0;
     gap: 8px;
@@ -68,7 +66,6 @@
     cursor: pointer;
     color: var(--text2, #bcbcc4);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     transition: background-color 0.15s ease;
 }
 

--- a/packages/frontend/app/components/Trade/OrderInput/OrderInput.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderInput.module.css
@@ -78,8 +78,6 @@
     border: none;
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
-    line-height: normal;
     cursor: pointer;
     flex-shrink: 0;
     gap: 8px;

--- a/packages/frontend/app/components/Trade/OrderInput/PlaceOrderButtons/PlaceOrderButtons.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/PlaceOrderButtons/PlaceOrderButtons.module.css
@@ -24,7 +24,6 @@
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-m, 18px);
     font-size: 16px;
-    font-weight: 400;
     outline: none;
     border: none;
 }

--- a/packages/frontend/app/components/Trade/OrderInput/PositionSIze/PositionSize.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/PositionSIze/PositionSize.module.css
@@ -9,9 +9,6 @@
 .containerTitle {
     color: var(--text2, #bcbcc4);
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .sliderWithValue {
@@ -138,7 +135,6 @@
     border: none;
     color: var(--text1);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     text-align: center;
     outline: none;
 }

--- a/packages/frontend/app/components/Trade/OrderInput/PriceRange/PriceRange.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/PriceRange/PriceRange.module.css
@@ -6,9 +6,7 @@
 }
 .label {
     color: var(--text2, #bcbcc4);
-
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
 }
 
 .inputsContainer {

--- a/packages/frontend/app/components/Trade/OrderInput/ReduceAndProfitToggle/ReduceAndProfitToggle.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/ReduceAndProfitToggle/ReduceAndProfitToggle.module.css
@@ -14,9 +14,7 @@
 }
 .toggleLabel {
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
 }
 .chasingIntervalContainer {
     display: flex;

--- a/packages/frontend/app/components/Trade/OrderInput/RunningTime/RunningTime.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/RunningTime/RunningTime.module.css
@@ -6,9 +6,7 @@
 }
 .label {
     color: var(--text2, #bcbcc4);
-
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
 }
 .inputContainer {
     display: grid;

--- a/packages/frontend/app/components/Trade/OrderInput/ScaleOrders/ScaleOrders.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/ScaleOrders/ScaleOrders.module.css
@@ -34,13 +34,8 @@
     justify-content: space-between;
     border-radius: var(--half-border-radius, 8px);
     background: var(--dark4, #27272c);
-
     color: var(--text1);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     outline: none;
     border: none;
 }
@@ -98,9 +93,6 @@
     gap: 4px;
     color: var(--text1, #f0f0f8) !important;
     font-size: var(--font-size-s, 12px) !important;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .dropdownToggle {
@@ -266,9 +258,6 @@
 .errorMessage {
     color: var(--red, #ef5350);
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .optionHeader {
     display: flex;

--- a/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.module.css
+++ b/packages/frontend/app/components/Trade/PositionsTable/PositionsTable.module.css
@@ -50,7 +50,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -59,7 +58,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/TradeHistoryTable/TradeHistoryTable.module.css
+++ b/packages/frontend/app/components/Trade/TradeHistoryTable/TradeHistoryTable.module.css
@@ -52,7 +52,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -61,7 +60,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/TwapTable/ActiveTwapTable/ActiveTwapTable.module.css
+++ b/packages/frontend/app/components/Trade/TwapTable/ActiveTwapTable/ActiveTwapTable.module.css
@@ -48,7 +48,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -57,7 +56,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/TwapTable/FillTwapTable/FillTwapTable.module.css
+++ b/packages/frontend/app/components/Trade/TwapTable/FillTwapTable/FillTwapTable.module.css
@@ -52,7 +52,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -61,7 +60,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Trade/TwapTable/HistoryTwapTable/HistoryTwapTable.module.css
+++ b/packages/frontend/app/components/Trade/TwapTable/HistoryTwapTable/HistoryTwapTable.module.css
@@ -48,7 +48,6 @@
 .cell {
     font-size: var(--font-size-s, 12px);
     color: var(--text1, #f0f0f8);
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -57,7 +56,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Tutorial/AdvancedTutorialModal.module.css
+++ b/packages/frontend/app/components/Tutorial/AdvancedTutorialModal.module.css
@@ -7,9 +7,9 @@
     bottom: 0;
     z-index: 1000;
     pointer-events: none; /* Allow clicking through most of the overlay */
-  }
-  
-  .overlay {
+}
+
+.overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -17,9 +17,9 @@
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.7);
     pointer-events: none;
-  }
-  
-  .spotlight {
+}
+
+.spotlight {
     position: absolute;
     box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.7);
     border-radius: 4px;
@@ -28,9 +28,9 @@
     border: 2px solid rgba(108, 92, 231, 0.8);
     box-sizing: content-box;
     pointer-events: none;
-  }
-  
-  .modalContent {
+}
+
+.modalContent {
     position: absolute;
     background-color: #1a1a2e;
     color: #fff;
@@ -43,45 +43,44 @@
     z-index: 1002;
     pointer-events: auto; /* Make the modal clickable */
     animation: fadeIn 0.3s ease-out;
-  }
-  
-  @keyframes fadeIn {
+}
+
+@keyframes fadeIn {
     from {
-      opacity: 0;
-      transform: translateY(10px);
+        opacity: 0;
+        transform: translateY(10px);
     }
     to {
-      opacity: 1;
-      transform: translateY(0);
+        opacity: 1;
+        transform: translateY(0);
     }
-  }
-  
-  .header {
+}
+
+.header {
     display: flex;
     align-items: center;
     padding: 16px;
     border-bottom: 1px solid #2a2a3e;
     position: relative;
-  }
-  
-  .stepIndicator {
+}
+
+.stepIndicator {
     background-color: #2a2a3e;
     color: #fff;
     padding: 4px 8px;
     border-radius: 4px;
     font-size: 12px;
     margin-right: 8px;
-  }
-  
-  .title {
+}
+
+.title {
     margin: 0;
     font-size: 18px;
-    font-weight: 600;
     flex-grow: 1;
     text-align: center;
-  }
-  
-  .closeButton {
+}
+
+.closeButton {
     position: absolute;
     right: 16px;
     top: 16px;
@@ -97,47 +96,47 @@
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-  }
-  
-  .closeButton:hover {
+}
+
+.closeButton:hover {
     background-color: rgba(255, 255, 255, 0.1);
     color: #fff;
-  }
-  
-  .body {
+}
+
+.body {
     padding: 16px;
     text-align: center;
     line-height: 1.5;
     color: #ddd;
-  }
-  
-  .navigationDots {
+}
+
+.navigationDots {
     display: flex;
     justify-content: center;
     gap: 6px;
     margin: 0 0 16px;
-  }
-  
-  .dot {
+}
+
+.dot {
     width: 8px;
     height: 8px;
     background-color: #444;
     border-radius: 50%;
     display: inline-block;
-  }
-  
-  .activeDot {
+}
+
+.activeDot {
     background-color: #6c5ce7;
-  }
-  
-  .footer {
+}
+
+.footer {
     display: flex;
     justify-content: space-between;
     padding: 16px;
     border-top: 1px solid #2a2a3e;
-  }
-  
-  .navigationButton {
+}
+
+.navigationButton {
     background-color: #2a2a3e;
     color: #fff;
     border: none;
@@ -146,21 +145,21 @@
     cursor: pointer;
     font-size: 14px;
     transition: background-color 0.2s;
-  }
-  
-  .navigationButton:hover:not(:disabled) {
+}
+
+.navigationButton:hover:not(:disabled) {
     background-color: #3a3a4e;
-  }
-  
-  .navigationButton:disabled {
+}
+
+.navigationButton:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-  
-  .primaryButton {
+}
+
+.primaryButton {
     background-color: #6c5ce7;
-  }
-  
-  .primaryButton:hover {
+}
+
+.primaryButton:hover {
     background-color: #5649c0;
-  }
+}

--- a/packages/frontend/app/components/Tutorial/TutorialModal.module.css
+++ b/packages/frontend/app/components/Tutorial/TutorialModal.module.css
@@ -10,9 +10,9 @@
     justify-content: center;
     align-items: center;
     z-index: 1000;
-  }
-  
-  .modalContent {
+}
+
+.modalContent {
     background-color: #1a1a2e;
     color: #fff;
     border-radius: 8px;
@@ -21,34 +21,33 @@
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     display: flex;
     flex-direction: column;
-  }
-  
-  .header {
+}
+
+.header {
     display: flex;
     align-items: center;
     padding: 16px;
     border-bottom: 1px solid #2a2a3e;
     position: relative;
-  }
-  
-  .stepIndicator {
+}
+
+.stepIndicator {
     background-color: #2a2a3e;
     color: #fff;
     padding: 4px 8px;
     border-radius: 4px;
     font-size: 12px;
     margin-right: 8px;
-  }
-  
-  .title {
+}
+
+.title {
     margin: 0;
     font-size: 18px;
-    font-weight: 600;
     flex-grow: 1;
     text-align: center;
-  }
-  
-  .closeButton {
+}
+
+.closeButton {
     position: absolute;
     right: 16px;
     top: 16px;
@@ -64,47 +63,47 @@
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-  }
-  
-  .closeButton:hover {
+}
+
+.closeButton:hover {
     background-color: rgba(255, 255, 255, 0.1);
     color: #fff;
-  }
-  
-  .body {
+}
+
+.body {
     padding: 16px;
     text-align: center;
     line-height: 1.5;
     color: #ddd;
-  }
-  
-  .navigationDots {
+}
+
+.navigationDots {
     display: flex;
     justify-content: center;
     gap: 6px;
     margin: 0 0 16px;
-  }
-  
-  .dot {
+}
+
+.dot {
     width: 8px;
     height: 8px;
     background-color: #444;
     border-radius: 50%;
     display: inline-block;
-  }
-  
-  .activeDot {
+}
+
+.activeDot {
     background-color: #6c5ce7;
-  }
-  
-  .footer {
+}
+
+.footer {
     display: flex;
     justify-content: space-between;
     padding: 16px;
     border-top: 1px solid #2a2a3e;
-  }
-  
-  .navigationButton {
+}
+
+.navigationButton {
     background-color: #2a2a3e;
     color: #fff;
     border: none;
@@ -113,21 +112,21 @@
     cursor: pointer;
     font-size: 14px;
     transition: background-color 0.2s;
-  }
-  
-  .navigationButton:hover:not(:disabled) {
+}
+
+.navigationButton:hover:not(:disabled) {
     background-color: #3a3a4e;
-  }
-  
-  .navigationButton:disabled {
+}
+
+.navigationButton:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-  
-  .primaryButton {
+}
+
+.primaryButton {
     background-color: #6c5ce7;
-  }
-  
-  .primaryButton:hover {
+}
+
+.primaryButton:hover {
     background-color: #5649c0;
-  }
+}

--- a/packages/frontend/app/components/Vault/DepositModal/DepositModal.module.css
+++ b/packages/frontend/app/components/Vault/DepositModal/DepositModal.module.css
@@ -25,9 +25,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -112,9 +109,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     padding: 8px;
     border-radius: var(--half-border-radius, 8px);
     border: 1px solid var(--dark4, #27272c);

--- a/packages/frontend/app/components/Vault/VaultCard/VaultCard.module.css
+++ b/packages/frontend/app/components/Vault/VaultCard/VaultCard.module.css
@@ -28,17 +28,10 @@
     align-items: flex-start;
     gap: 4px;
     flex: 1 0 0;
-
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .headerTextContainer h3 {
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-l, 24px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .headerTextContainer h6 {
     color: var(--text2, #bcbcc4);
@@ -101,12 +94,7 @@
     outline: none;
     border: none;
     color: var(--text1, #f0f0f8);
-
-    /* Main/L */
     font-size: var(--font-size-l, 24px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .buttonContainer {
     width: 100%;
@@ -124,17 +112,10 @@
     justify-content: center;
     align-items: center;
     flex: 1 0 0;
-
     color: var(--text1, #f0f0f8);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
-
     outline: none;
     border: none;
-
     border-radius: 8px;
     transition: all var(--ease-in-out-med);
 }

--- a/packages/frontend/app/components/Vault/VaultRow/VaultRow.module.css
+++ b/packages/frontend/app/components/Vault/VaultRow/VaultRow.module.css
@@ -13,10 +13,7 @@
 }
 .headerCell {
     color: var(--text2, #6a6a6d);
-
     font-size: var(--font-size-s, 12px);
-
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/components/Vault/VaultTimeframe/VaultTimeframe.module.css
+++ b/packages/frontend/app/components/Vault/VaultTimeframe/VaultTimeframe.module.css
@@ -10,7 +10,6 @@
     background-color: transparent;
     color: white;
     font-size: 12px;
-    font-weight: 500;
     border: none;
     display: flex;
     justify-content: space-between;

--- a/packages/frontend/app/components/Vault/WithdrawModal/WithdrawModal.module.css
+++ b/packages/frontend/app/components/Vault/WithdrawModal/WithdrawModal.module.css
@@ -13,9 +13,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .textContent h4 {
     color: var(--text1, #f0f0f8);
@@ -76,9 +73,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     padding: 8px;
     border-radius: var(--half-border-radius, 8px);
     border: 1px solid var(--dark4, #27272c);

--- a/packages/frontend/app/css/index.css
+++ b/packages/frontend/app/css/index.css
@@ -59,6 +59,8 @@
     --trade-module-width-desktop-small: 280px;
 
     /* fonts */
+
+    --font-weight: 400;
     --font-family-main: 'Lexend Deca';
 
     --font-size-xs: 10px;
@@ -103,7 +105,8 @@ html {
 
 body {
     font-family: var(--font-family-main, 'Lexend Deca');
-    line-height: 1.5;
+    font-weight: var(--font-weight, 400);
+    line-height: normal;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     background: var(--dark1);

--- a/packages/frontend/app/routes/home/home.module.css
+++ b/packages/frontend/app/routes/home/home.module.css
@@ -47,7 +47,6 @@
 
 .left h1 {
     font-size: 2.7rem;
-    font-weight: 700;
     margin-bottom: 1rem;
     line-height: 1.2;
 }
@@ -70,7 +69,6 @@
     color: white;
     border: none;
     border-radius: 12px;
-    font-weight: bold;
     cursor: pointer;
     transition: all 0.3s ease;
 }
@@ -86,7 +84,6 @@
     border: 2px solid #7371fc;
     color: #7371fc;
     border-radius: 12px;
-    font-weight: bold;
     cursor: pointer;
     transition: all 0.3s ease;
 }

--- a/packages/frontend/app/routes/leaderboard/leaderboard.module.css
+++ b/packages/frontend/app/routes/leaderboard/leaderboard.module.css
@@ -13,9 +13,6 @@
 .container header {
     color: #fff;
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .content {
@@ -47,13 +44,8 @@
     justify-content: center;
     align-items: center;
     gap: 4px;
-
     color: var(--text2, #bcbcc4);
-
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 .searchContainer svg:hover {
     fill: var(--text1);
@@ -183,9 +175,6 @@
     color: var(--text2, #bcbcc4);
     text-align: center;
     font-size: var(--font-size-s, 12px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     align-self: stretch;
 }
 .periodSelectorContainer {

--- a/packages/frontend/app/routes/more/more.module.css
+++ b/packages/frontend/app/routes/more/more.module.css
@@ -18,9 +18,6 @@
 .title {
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-xxl, 64px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .grid {
@@ -49,13 +46,11 @@
     gap: 16px;
     color: var(--text1, #f0f0f8);
     font-size: var(--font-fize-l, 24px);
-    font-weight: 400;
 }
 
 .description {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
 }
 
 .button {
@@ -68,7 +63,6 @@
     background: var(--accent1, #7371fc);
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     text-decoration: none;
 }
 

--- a/packages/frontend/app/routes/notFound/notFound.module.css
+++ b/packages/frontend/app/routes/notFound/notFound.module.css
@@ -1,4 +1,10 @@
 .container {
+    --notFound-font-weight-boldest: 700;
+    --notFound-font-weight-bold: 600;
+    --notFound-font-weight-medium: 500;
+    --notFound-font-size-errorCode: 120px;
+    --notFound-font-size-errorCode-sm: 80px;
+
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -13,17 +19,17 @@
 .content {
     max-width: 500px;
     margin: 0 auto;
-    padding: 32px;
+    padding: var(--header-link-gap);
     border-radius: var(--main-border-radius);
     background-color: var(--dark3);
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
 }
 
 .errorCode {
-    font-size: 120px;
-    font-weight: 700;
+    font-size: var(--notFound-font-size-errorCode);
+    font-weight: var(--notFound-font-weight-boldest);
     line-height: 1;
-    margin-bottom: 24px;
+    margin-bottom: var(--font-size-l);
     background: linear-gradient(
         90deg,
         var(--accent1),
@@ -36,34 +42,34 @@
 }
 
 .title {
-    font-size: 32px;
-    font-weight: 600;
-    margin-bottom: 16px;
+    font-size: var(--font-size-xl);
+    font-weight: var(--notFound-font-weight-bold);
+    margin-bottom: var(--font-size-m);
     color: var(--text1);
 }
 
 .message {
-    font-size: 18px;
+    font-size: var(--font-size-m);
     line-height: 1.5;
-    margin-bottom: 32px;
+    margin-bottom: var(--header-link-gap);
     color: var(--text2);
 }
 
 .actions {
     display: flex;
-    gap: 16px;
+    gap: var(--main-border-radius);
     justify-content: center;
     flex-wrap: wrap;
 }
 
 .primaryButton {
-    padding: 12px 24px;
+    padding: var(--font-size-s) var(--font-size-l);
     background: linear-gradient(90deg, var(--accent1), var(--accent4));
     color: var(--text1);
     border: none;
     border-radius: var(--half-border-radius);
-    font-size: 16px;
-    font-weight: 500;
+    font-size: var(--font-size-m);
+    font-weight: var(--notFound-font-weight-medium);
     cursor: pointer;
     transition: all 0.2s ease;
 }
@@ -74,13 +80,13 @@
 }
 
 .secondaryButton {
-    padding: 12px 24px;
+    padding: var(--notFound-padding-button);
     background-color: var(--dark5);
     color: var(--text1);
     border: none;
     border-radius: var(--half-border-radius);
-    font-size: 16px;
-    font-weight: 500;
+    font-size: var(--notFound-font-size-button);
+    font-weight: var(--notFound-font-weight-medium);
     cursor: pointer;
     transition: all 0.2s ease;
 }
@@ -90,28 +96,27 @@
     transform: translateY(-2px);
 }
 
-/* Responsive adjustments */
 @media (max-width: 768px) {
     .errorCode {
-        font-size: 100px;
+        font-size: var(--font-size-xxl);
     }
 
     .title {
-        font-size: 28px;
+        font-size: var(--font-size-l);
     }
 
     .message {
-        font-size: 16px;
+        font-size: var(--font-size-m);
     }
 }
 
 @media (max-width: 480px) {
     .errorCode {
-        font-size: 80px;
+        font-size: var(--notFound-font-size-errorCode-sm);
     }
 
     .title {
-        font-size: 24px;
+        font-size: var(--font-size-m);
     }
 
     .actions {

--- a/packages/frontend/app/routes/orderHistory/orderHistory.module.css
+++ b/packages/frontend/app/routes/orderHistory/orderHistory.module.css
@@ -13,9 +13,6 @@
 .container header {
     color: #fff;
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .content {

--- a/packages/frontend/app/routes/portfolio/portfolio.module.css
+++ b/packages/frontend/app/routes/portfolio/portfolio.module.css
@@ -12,9 +12,6 @@
 .container header {
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 .column {
     height: 100%;
@@ -26,9 +23,6 @@
     height: 100%;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     gap: 4px;
 }
 .detailsContent {

--- a/packages/frontend/app/routes/positions/positions.module.css
+++ b/packages/frontend/app/routes/positions/positions.module.css
@@ -13,9 +13,6 @@
 .container header {
     color: #fff;
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .content {

--- a/packages/frontend/app/routes/referrals/referrals.module.css
+++ b/packages/frontend/app/routes/referrals/referrals.module.css
@@ -14,17 +14,11 @@
 .container header {
     color: var(--text1, #f0f0f8);
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .container header p {
     color: var(--text2, #bcbcc4);
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .container header p a {
@@ -36,9 +30,6 @@
     flex-direction: row;
     align-items: center;
     gap: 5rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
 }
 
 .detailsContent {

--- a/packages/frontend/app/routes/subaccounts/CreateSubaccount/CreateSubaccount.module.css
+++ b/packages/frontend/app/routes/subaccounts/CreateSubaccount/CreateSubaccount.module.css
@@ -35,7 +35,6 @@
     border: none;
     border-radius: var(--half-border-radius);
     font-size: var(--font-size-m);
-    font-weight: 400;
     color: var(--text1);
 }
 

--- a/packages/frontend/app/routes/trade/symbol/symbolsearch/symbollist/symbollist.module.css
+++ b/packages/frontend/app/routes/trade/symbol/symbolsearch/symbollist/symbollist.module.css
@@ -82,7 +82,6 @@
 .headerCell {
     color: var(--text2, #6a6a6d);
     font-size: var(--font-size-xs, 10px);
-    font-weight: 400;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/app/routes/tradeHistory/tradeHistory.module.css
+++ b/packages/frontend/app/routes/tradeHistory/tradeHistory.module.css
@@ -13,9 +13,6 @@
 .container header {
     color: #fff;
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .content {

--- a/packages/frontend/app/routes/twapFillHistory/twapFillHistory.module.css
+++ b/packages/frontend/app/routes/twapFillHistory/twapFillHistory.module.css
@@ -13,9 +13,6 @@
 .container header {
     color: #fff;
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .content {

--- a/packages/frontend/app/routes/twapHistory/twapHistory.module.css
+++ b/packages/frontend/app/routes/twapHistory/twapHistory.module.css
@@ -13,9 +13,6 @@
 .container header {
     color: #fff;
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 
 .content {

--- a/packages/frontend/app/routes/vaults/vaults.module.css
+++ b/packages/frontend/app/routes/vaults/vaults.module.css
@@ -25,19 +25,11 @@
     height: 47px;
     align-self: stretch;
     color: var(--text1, #e1eeee);
-
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 .totalValueContainer p {
     color: var(--colors-text1, #e1eeee);
-
     font-size: var(--font-size-m, 18px);
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
     display: flex;
     flex-direction: row;
     gap: 16px;
@@ -85,10 +77,7 @@
     outline: none;
     border: none;
     color: var(--core-text2, #6a6a6d);
-
-    /* Main/S */
-    font-size: var(--ont-size-s, 12px);
-    font-weight: 400;
+    font-size: var(--font-size-s, 12px);
 }
 .tableContainer header {
     height: 66px;
@@ -123,7 +112,6 @@
     justify-content: center;
     align-items: center;
     font-size: var(--font-size-s, 12px);
-    font-weight: 400;
     border-radius: 8px;
 }
 .activeFilterButton {

--- a/packages/frontend/app/routes/vaults/vaultsNew.module.css
+++ b/packages/frontend/app/routes/vaults/vaultsNew.module.css
@@ -15,9 +15,6 @@
     gap: 16px;
     color: var(--text1, #e1eeee);
     font-size: var(--font-size-xl, 36px);
-    font-style: normal;
-    font-weight: 300;
-    line-height: normal;
 }
 .container header a {
     color: var(--accent1, #7371fc);


### PR DESCRIPTION
## 🧹 Consolidate Font Weight, Font Style, and Line Height Usage

This PR continues the typography cleanup by centralizing `font-weight`, `font-style`, and `line-height` definitions into the global `body` selector within `index.css`.

---

### ✅ What’s Changed

- Created a CSS variable `--font-weight` (value: `400`) in `index.css`
- Applied `font-weight: var(--font-weight)`, `font-style: normal`, and `line-height: normal` to the `body`
- Removed **all other instances** of `font-weight`, `font-style`, and `line-height` from the entire app
- **Exception:** `NotFound.module.css` contains its own locally scoped `font-weight` declarations (intended and allowed)

---

### 🎯 Result

- Typography is now consistently styled across the app
- All relevant text properties (`font-weight`, `font-style`, `line-height`) are set **only once** at the global level
- Any overrides outside of `NotFound.module.css` have been **removed**

---

Let me know if you want to enforce this in lint rules or style guides going forward 👀
