### PR TITLE
OrderBook | Order count calculation logic change

### DIFF
--- a/packages/frontend/app/routes/trade/orderbook/orderbook.module.css
+++ b/packages/frontend/app/routes/trade/orderbook/orderbook.module.css
@@ -46,3 +46,12 @@
     height: 100%;
     opacity: 0.2;
 }
+
+.dummyOrderRow {
+    position: fixed;
+    top: -100vh;
+    left: 0;
+    background-color: var(--dark4);
+    z-index: -1;
+    opacity: 0;
+}

--- a/packages/frontend/app/routes/trade/orderbook/orderbook.tsx
+++ b/packages/frontend/app/routes/trade/orderbook/orderbook.tsx
@@ -28,6 +28,16 @@ interface OrderBookProps {
     orderCount: number;
 }
 
+const dummyOrder: OrderBookRowIF = {
+    coin: 'BTC',
+    px: 10000,
+    sz: 1,
+    type: 'buy',
+    ratio: 0.5,
+    n: 0,
+    total: 0,
+};
+
 const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
     // FIXME: data is not rendered on UI
 
@@ -341,6 +351,17 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
 
             <BasicDivider />
 
+            <div id='dummyOrderRow' className={styles.dummyOrderRow}>
+                <OrderRow
+                    rowIndex={0}
+                    order={dummyOrder}
+                    coef={1}
+                    resolution={filledResolution.current}
+                    userSlots={userBuySlots}
+                    clickListener={() => {}}
+                />
+            </div>
+
             {orderBookState === TableState.LOADING && (
                 <motion.div
                     className={styles.skeletonWrapper}
@@ -351,13 +372,13 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
                 >
                     <div
                         className={styles.orderBookBlock}
-                        style={{ gap: '.26rem' }}
+                        style={{ gap: '.4rem' }}
                     >
                         {Array.from({ length: orderCount }).map((_, index) => (
                             <div key={index} className={styles.orderRowWrapper}>
                                 <SkeletonNode
                                     width={getRandWidth(index)}
-                                    height={'19px'}
+                                    height={'15px'}
                                 />
                             </div>
                         ))}
@@ -365,13 +386,13 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
                     {midHeader('orderBookMidHeader2')}
                     <div
                         className={styles.orderBookBlock}
-                        style={{ gap: '.26rem' }}
+                        style={{ gap: '.4rem' }}
                     >
                         {Array.from({ length: orderCount }).map((_, index) => (
                             <div key={index} className={styles.orderRowWrapper}>
                                 <SkeletonNode
                                     width={getRandWidth(index, true)}
-                                    height={'19px'}
+                                    height={'15px'}
                                 />
                             </div>
                         ))}
@@ -419,7 +440,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
                                             <div
                                                 className={styles.ratioBar}
                                                 style={{
-                                                    width: `${order.ratio * 100}%`,
+                                                    width: `${order.ratio ?? 0 * 100}%`,
                                                     backgroundColor:
                                                         order.type === 'sell'
                                                             ? getBsColor().sell
@@ -459,7 +480,7 @@ const OrderBook: React.FC<OrderBookProps> = ({ symbol, orderCount }) => {
                                             <div
                                                 className={styles.ratioBar}
                                                 style={{
-                                                    width: `${order.ratio * 100}%`,
+                                                    width: `${order.ratio ?? 0 * 100}%`,
                                                     backgroundColor:
                                                         order.type === 'buy'
                                                             ? getBsColor().buy

--- a/packages/frontend/app/routes/trade/orderbook/orderbooksection.tsx
+++ b/packages/frontend/app/routes/trade/orderbook/orderbooksection.tsx
@@ -38,6 +38,13 @@ const OrderBookSection: React.FC<OrderBookSectionProps> = ({
     const calculateOrderCount = () => {
         const orderBookSection = document.getElementById('orderBookSection');
 
+        const dummyOrderRow = document.getElementById('dummyOrderRow');
+
+        const orderRowHeight =
+            dummyOrderRow?.getBoundingClientRect().height || 16;
+
+        const orderRowHeightWithGaps = orderRowHeight + 5;
+
         if (orderBookSection) {
             let availableHeight =
                 orderBookSection.getBoundingClientRect().height;
@@ -66,7 +73,8 @@ const OrderBookSection: React.FC<OrderBookSectionProps> = ({
                             .getElementById('orderBookMidHeader')
                             ?.getBoundingClientRect()?.height || 0;
                     const orderCount = Math.floor(
-                        (availableHeight - otherHeightSum) / 49,
+                        (availableHeight - otherHeightSum) /
+                            (orderRowHeightWithGaps * 2),
                     );
                     setOrderCount(orderCount);
                     setTradesCount(Math.floor(availableHeight / 21));


### PR DESCRIPTION
Order count calculation logic has been changed to use a dummy order row height value rather than using magic numbers
A mock row has been added into page and hidden, that row is using to detect standard row height
Than formula is working to decide how many order rows should be rendered in OrderBook section

Note:
Skeleton height changes also have been changed, same logic will be implemented to that skeleton heights