### PR TITLE
fix: chart loading screen color is grey on first deploy

### DIFF
--- a/packages/frontend/app/contexts/TradingviewContext.tsx
+++ b/packages/frontend/app/contexts/TradingviewContext.tsx
@@ -200,6 +200,9 @@ export const TradingViewProvider: React.FC<{ children: React.ReactNode }> = ({
             custom_themes: customThemes(),
             overrides: {
                 volumePaneSize: 'medium',
+                'paneProperties.background': '#0e0e14',
+                'paneProperties.backgroundGradientStartColor': '#0e0e14',
+                'paneProperties.backgroundGradientEndColor': '#0e0e14',
             },
             custom_css_url: './../tradingview-overrides.css',
             loading_screen: { backgroundColor: '#0e0e14' },
@@ -220,11 +223,6 @@ export const TradingViewProvider: React.FC<{ children: React.ReactNode }> = ({
         });
 
         tvWidget.onChartReady(() => {
-            tvWidget.applyOverrides({
-                'paneProperties.background': '#0e0e14',
-                'paneProperties.backgroundType': 'solid',
-            });
-
             /**
              * 0 -> main chart pane
              * 1 -> volume chart pane


### PR DESCRIPTION
The issue occurs on the first load in an private chrome tab or during the initial deployment