### PR TITLE
complete frontend review for watchlist and market info

### DIFF
--- a/packages/frontend/app/routes/trade/symbol/symbolinfo.tsx
+++ b/packages/frontend/app/routes/trade/symbol/symbolinfo.tsx
@@ -75,17 +75,20 @@ const SymbolInfo: React.FC = () => {
                                 id='tutorial-pool-info'
                             >
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='Mark'
                                     valueClass={'w4'}
                                     value={formatNum(symbolInfo?.markPx)}
                                     lastWsChange={symbolInfo?.lastPriceChange}
                                 />
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='Oracle'
                                     valueClass={'w4'}
                                     value={formatNum(symbolInfo?.oraclePx)}
                                 />
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='24h Change'
                                     valueClass={'w7'}
                                     value={get24hChangeString().str}
@@ -98,6 +101,7 @@ const SymbolInfo: React.FC = () => {
                                     }
                                 />
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='24h Volume'
                                     valueClass={'w7'}
                                     value={
@@ -106,6 +110,7 @@ const SymbolInfo: React.FC = () => {
                                     }
                                 />
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='Open Interest'
                                     valueClass={'w7'}
                                     value={
@@ -118,6 +123,7 @@ const SymbolInfo: React.FC = () => {
                                     }
                                 />
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='Funding Rate'
                                     valueClass={'w7'}
                                     value={
@@ -128,6 +134,7 @@ const SymbolInfo: React.FC = () => {
                                     type={'positive'}
                                 />
                                 <SymbolInfoField
+                                    tooltipContent='tooltip content'
                                     label='Funding Countdown'
                                     valueClass={'w7'}
                                     value={getTimeUntilNextHour()}

--- a/packages/frontend/app/routes/trade/symbol/symbolinfofield/symbolinfofield.module.css
+++ b/packages/frontend/app/routes/trade/symbol/symbolinfofield/symbolinfofield.module.css
@@ -19,10 +19,22 @@
 
 .symbolInfoFieldLabel {
     color: var(--text2);
-    padding-right: 1rem;
+    padding-right: var(--padding-m);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+.tooltip {
+    width: 15px;
+    animation: fadeIn 0.1s ease-in-out;
+    opacity: 0;
 }
 
 .symbolInfoFieldValue {
     color: var(--text1);
     margin-top: 0.2rem;
+}
+.symbolInfoField:hover .tooltip {
+    opacity: 1;
 }

--- a/packages/frontend/app/routes/trade/symbol/symbolinfofield/symbolinfofield.tsx
+++ b/packages/frontend/app/routes/trade/symbol/symbolinfofield/symbolinfofield.tsx
@@ -3,6 +3,8 @@ import styles from './symbolinfofield.module.css';
 
 import { motion } from 'framer-motion';
 import SkeletonNode from '~/components/Skeletons/SkeletonNode/SkeletonNode';
+import Tooltip from '~/components/Tooltip/Tooltip';
+import { AiOutlineQuestionCircle } from 'react-icons/ai';
 
 interface SymbolInfoFieldProps {
     label: string;
@@ -11,6 +13,7 @@ interface SymbolInfoFieldProps {
     type?: 'positive' | 'negative';
     valueClass?: string;
     skeleton?: boolean;
+    tooltipContent?: string;
 }
 
 const SymbolInfoField: React.FC<SymbolInfoFieldProps> = ({
@@ -20,6 +23,7 @@ const SymbolInfoField: React.FC<SymbolInfoFieldProps> = ({
     type,
     valueClass,
     skeleton = false,
+    tooltipContent,
 }) => {
     const { getBsColor } = useAppSettings();
 
@@ -76,7 +80,16 @@ const SymbolInfoField: React.FC<SymbolInfoFieldProps> = ({
     return (
         <div className={styles.symbolInfoFieldWrapper}>
             <div className={`${styles.symbolInfoField}`}>
-                <div className={styles.symbolInfoFieldLabel}>{label}</div>
+                <div className={styles.symbolInfoFieldLabel}>
+                    {label}
+                    {tooltipContent && (
+                        <div className={styles.tooltip}>
+                            <Tooltip content={tooltipContent} position='right'>
+                                <AiOutlineQuestionCircle size={13} />
+                            </Tooltip>
+                        </div>
+                    )}
+                </div>
                 {renderValue()}
             </div>
         </div>

--- a/packages/frontend/app/routes/trade/symbol/symbolsearch/symbolsearch.module.css
+++ b/packages/frontend/app/routes/trade/symbol/symbolsearch/symbolsearch.module.css
@@ -1,4 +1,8 @@
 .symbolSearchBackdrop {
+    --search-container-height: 40px;
+    --search-container-width: 160px;
+
+    --symbol-width-height: 30px;
     position: relative;
 }
 
@@ -7,15 +11,23 @@
     align-items: center;
     justify-content: center;
     gap: var(--gap-s);
-    font-size: 1.2rem;
+
+    font-size: var(--font-size-l);
     user-select: none;
-    min-width: 10rem;
+    min-width: var(--search-container-width);
+    height: var(--search-container-height);
     cursor: pointer;
+    padding: 0 var(--padding-s);
+    border-radius: var(--radius-s);
 }
 
+.symbolSearchContainer:hover {
+    background-color: var(--bg-dark3);
+    transition: all 0.3s ease-in-out;
+}
 .symbolIcon {
-    width: 1.4rem;
-    height: 1.4rem;
+    width: var(--symbol-width-height);
+    height: var(--symbol-width-height);
     border-radius: var(--radius-m);
 }
 
@@ -26,7 +38,7 @@
 .comboBoxIcon {
     transition: var(--ease-in-out-fast);
     transform: rotate(0deg);
-    font-size: 0.7rem;
+    font-size: var(--font-size-s);
     opacity: 0.3;
 }
 

--- a/packages/frontend/app/routes/trade/watchlist/watchlist.module.css
+++ b/packages/frontend/app/routes/trade/watchlist/watchlist.module.css
@@ -7,6 +7,9 @@
     }
 }
 .watchListContainer {
+    --svg-width-height: 25px;
+    --svg-padding: 4.5px;
+
     width: 100%;
     height: 100%;
     display: flex;
@@ -47,6 +50,17 @@
     gap: var(--gap-m);
 }
 
+.watchListToolbarIcon,
+.favIcon {
+    padding: var(--svg-padding);
+    border-radius: var(--radius-s);
+    width: var(--svg-width-height);
+    height: var(--svg-width-height);
+}
+.watchListToolbarIcon:hover,
+.favIcon:hover {
+    background: var(--bg-dark3);
+}
 .watchListLimitor {
     max-width: calc(
         100vw - var(--order-book-width-desktop-small) -

--- a/packages/frontend/app/routes/trade/watchlist/watchlistnode/watchlistnode.module.css
+++ b/packages/frontend/app/routes/trade/watchlist/watchlistnode/watchlistnode.module.css
@@ -21,7 +21,7 @@
 }
 
 .watchListNodeContent:not(.active):hover {
-    background-color: var(--bg-dark4) !important;
+    background-color: var(--bg-dark3) !important;
 }
 
 .watchListNodeContainer div {


### PR DESCRIPTION
<img width="733" alt="image" src="https://github.com/user-attachments/assets/8e2b7ba3-5be2-440d-b854-6a56a2888614" />

- Watchlist has too much left padding
- Hover state for watched markets should be dark3, looks like dark4
- Market info area has too much left padding
- Add a hoverstate to the market select area - refer figma
- Need a hover state and tooltip for things in the market details like oracle price etc
- Can the “dollars/percent” buttons also have an area around it for the hover state - refer figma
- 
