### PR TITLE
Search box frontend review

### DIFF
--- a/packages/frontend/app/routes/trade/orderbook/orderbooksection.module.css
+++ b/packages/frontend/app/routes/trade/orderbook/orderbooksection.module.css
@@ -58,10 +58,10 @@
 .menuContent {
     display: flex;
     justify-content: center;
+    align-items: center;
 
     height: 100%;
     width: 100%;
-    justify-content: center;
-    align-items: center;
-    padding-bottom: var(--padding-s);
+
+    /* padding-bottom: var(--padding-s); */
 }

--- a/packages/frontend/app/routes/trade/symbol/symbolsearch/symbollist/SymbolListTableRow.tsx
+++ b/packages/frontend/app/routes/trade/symbol/symbolsearch/symbollist/SymbolListTableRow.tsx
@@ -62,7 +62,7 @@ export default function SymbolListTableRow(props: SymbolListTableRowProps) {
                         onClick={handleFavClick}
                     />
                 )}
-                <div className={styles.symbolName}>{symbol.coin} - USD</div>
+                <div className={styles.symbolName}>{symbol.coin}-USD</div>
                 <div className={styles.leverageLabel}>
                     {symbol.maxLeverage}x
                 </div>

--- a/packages/frontend/app/routes/trade/symbol/symbolsearch/symbollist/symbollist.module.css
+++ b/packages/frontend/app/routes/trade/symbol/symbolsearch/symbollist/symbollist.module.css
@@ -4,6 +4,7 @@
     --symbol-list-input-height: 31px;
     --table-header-height: 24px;
     --row-container-height: 17px;
+    --leverage-pill-height: 15px;
 
     position: absolute;
     top: 130%;
@@ -142,10 +143,14 @@
 }
 
 .symbolListWrapper .leverageLabel {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     color: var(--text1);
     background: var(--accent1) !important;
-    padding: 0 0.2rem !important;
-    border-radius: 0.2rem !important;
+    padding: var(--padding-xs);
+    border-radius: var(--radius-xs) !important;
+    height: var(--leverage-pill-height);
 }
 
 .symbolListSearchClose {


### PR DESCRIPTION
fix menu dot alignment
SEARCH BOX - i would like to line up the search box with the top and left of the chart. This way the search will line up with the market button above 
SEARCH BOX - search field border radius should be 8
SEARCH BOX - reduce the height of the leverage pill. It should be smaller than the row height. In figma i have a row height of 17, a leverage pill height of 15, left padding of 4, and right padding of 8, and a gap between rows of 4
SEARCH BOX - add border radius to the rows - 4px
SEARCH BOX - we can remove the spaces from the market names eg. BTC-USD
