### PR TITLE
Fix pagination logic: correctly compute last page index and disable Next” on final page

### DIFF
--- a/packages/frontend/app/components/Pagination/GenericTablePagination.tsx
+++ b/packages/frontend/app/components/Pagination/GenericTablePagination.tsx
@@ -85,13 +85,14 @@ const GenericTablePagination: React.FC<GenericTablePaginationProps> = ({
                         className={styles.pageButton}
                         onClick={() => {
                             if (
-                                page < Math.floor(totalCount / rowsPerPageState)
+                                page <
+                                Math.ceil(totalCount / rowsPerPageState) - 1
                             ) {
                                 setPage(page + 1);
                             }
                         }}
                         disabled={
-                            page === Math.floor(totalCount / rowsPerPageState)
+                            page >= Math.ceil(totalCount / rowsPerPageState) - 1
                         }
                     >
                         <FaChevronRight size={20} />


### PR DESCRIPTION
Updated GenericTablePagination.tsx to fix pagination logic: correctly compute last page index and disable Next” on final page