### PR TITLE
Wrong market showing on chart when refresh page

### DIFF
--- a/packages/frontend/app/contexts/TradingviewContext.tsx
+++ b/packages/frontend/app/contexts/TradingviewContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 import { useSdk } from '~/hooks/useSdk';
 import { getMarkFillData } from '~/routes/chart/data/candleDataCache';
 import { createDataFeed } from '~/routes/chart/data/customDataFeed';
@@ -76,7 +77,7 @@ export const TradingViewProvider: React.FC<{ children: React.ReactNode }> = ({
     const { showBuysSellsOnChart } = useAppOptions();
 
     const [isChartReady, setIsChartReady] = useState(false);
-
+    const { marketId } = useParams<{ marketId: string }>();
     useEffect(() => {
         const res = getChartLayout();
         setChartState(res);
@@ -183,7 +184,7 @@ export const TradingViewProvider: React.FC<{ children: React.ReactNode }> = ({
             container: 'tv_chart',
             library_path: defaultProps.libraryPath,
             timezone: 'Etc/UTC',
-            symbol: symbol,
+            symbol: marketId,
             fullscreen: false,
             autosize: true,
             datafeed: createDataFeed(info) as IBasicDataFeed,


### PR DESCRIPTION
**Functionalities or workflows that should specifically be tested:**

1. Open the trade page in one browser tab (https://.../trade/BTC)
2. Open the same trade page in a new browser tab 
3. In one of the new tabs, change the selected pool (https://.../trade/DOGE)
4. Go back to the original tab and refresh the page
5. Verify that the original tab shows the pool based on its own URL

**Previously:** Refreshing a tab after changing the pool in another tab would show the other tab's selected pool in the chart
**Now expected:** Each tab should display the pool according to its own URL, even after a page refresh.