### PR TITLE
Websocket | Fix Reconnect Issue for MultiSocketInfo

### DIFF
--- a/packages/frontend/app/hooks/useSdk.tsx
+++ b/packages/frontend/app/hooks/useSdk.tsx
@@ -146,7 +146,7 @@ export const SdkProvider: React.FC<{
 
     const stashWebsocket = useCallback(() => {
         if (info?.multiSocketInfo) {
-            info?.multiSocketInfo?.stop();
+            info.multiSocketInfo.stop();
         } else {
             info?.wsManager?.stop();
         }

--- a/packages/sdk/src/websocket-instance.ts
+++ b/packages/sdk/src/websocket-instance.ts
@@ -702,4 +702,18 @@ export class WebSocketInstance {
     public setConnectionChangeHandler(handler: (connected: boolean) => void) {
         this.onConnectionChange = handler;
     }
+
+    // [22-07-2025] for stashing subs in useSdk hook
+    public getActiveSubscriptions() {
+        return this.activeSubscriptions;
+    }
+
+    // [22-07-2025] is being used while re-initializing ws
+    public addToQueuedSubs(subscription: ActiveSubscription) {
+        console.log('>>> add to queue');
+        this.queuedSubscriptions.push({
+            subscription: subscription.subscription,
+            active: subscription,
+        });
+    }
 }


### PR DESCRIPTION
Reconnect issue has been fixed for multi socket approach.
_Problem is being triggered after 30m timeout which stops active sockets._

Stashing active subs and reInit action for active sockets has been implemented