### PR TITLE
remove margin modal CTA

### DIFF
--- a/packages/frontend/app/components/Trade/OrderInput/MarginModal/MarginModal.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/MarginModal/MarginModal.module.css
@@ -1,26 +1,19 @@
 /* top-level return for `MarginModal.tsx` file */
 .margin_modal_content {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--gap-m);
     width: 708px;
     height: auto;
     padding: var(--padding-s) var(--padding-m) var(--padding-m) 16px;
     align-items: flex-start;
-    gap: var(--gap-s);
-}
-
-/* organizational wrapper for mode toggle buttons */
-.margin_modal_buttons {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--gap-m);
 
     /* centralized CSS for border to apply situationally */
     --margin_modal_button_border: 1px solid var(--accent1);
 }
 
 /* clickable buttons to change the current margin mode */
-.margin_modal_buttons > button {
+.margin_modal_content > button {
     border-radius: var(--radius-m, 16px);
     border: 1px solid var(--bg-dark4);
     background: var(--bg-dark4, #27272c);
@@ -39,19 +32,18 @@
 }
 
 /* hover effect for margin mode buttons */
-.margin_modal_buttons > button:hover {
+.margin_modal_content > button:hover {
     border: var(--margin_modal_button_border) !important;
 }
 
 /* headline text inside each margin mode button */
-.margin_modal_buttons > button > h3 {
+.margin_modal_content > button > h3 {
     font-size: var(--font-size-m, 18px);
     color: var(--text1);
 }
 
 .selected {
     border: var(--margin_modal_button_border) !important;
-    background-color: green;
 }
 
 @media (max-width: 768px) {
@@ -59,7 +51,7 @@
         width: auto;
     }
 
-    .margin_modal_buttons {
+    .margin_modal_content {
         display: flex;
         flex-direction: column;
     }

--- a/packages/frontend/app/components/Trade/OrderInput/MarginModal/MarginModal.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/MarginModal/MarginModal.tsx
@@ -1,56 +1,41 @@
-import { useState } from 'react';
 import styles from './MarginModal.module.css';
-import SimpleButton from '~/components/SimpleButton/SimpleButton';
 import { type marginModesT } from '~/stores/TradeDataStore';
 
-interface PropsIF {
+interface propsIF {
     initial: marginModesT;
     handleConfirm: (m: marginModesT) => void;
 }
-export default function MarginModal(props: PropsIF) {
-    const { initial, handleConfirm } = props;
 
-    // hook to track the current selection before updating settings
-    const [selected, setSelected] = useState<marginModesT>(initial);
+export default function MarginModal(props: propsIF) {
+    const { initial, handleConfirm } = props;
 
     return (
         <section className={styles.margin_modal_content}>
-            <div className={styles.margin_modal_buttons}>
-                <button
-                    className={styles[selected === 'cross' ? 'selected' : '']}
-                    onClick={() => setSelected('cross')}
-                >
-                    <h3>Cross Margin</h3>
-                    <p>
-                        All cross positions share the same cross margin as
-                        collateral. In the event of liquidation, your cross
-                        margin balance and any remaining open positions under
-                        assets in this mode may be forfeited.
-                    </p>
-                </button>
-                <button
-                    className={
-                        styles[selected === 'isolated' ? 'selected' : '']
-                    }
-                    onClick={() => setSelected('isolated')}
-                >
-                    <h3>Isolated Mode</h3>
-                    <p>
-                        Manage your risk on individual positions by restricting
-                        the amount of margin allocated to each. If the margin
-                        ratio of an isolated position reaches 100%, the position
-                        will be liquidated. Margin can be added or removed to
-                        individual positions in this mode.
-                    </p>
-                </button>
-            </div>
-            <SimpleButton
-                bg='accent1'
-                onClick={() => handleConfirm(selected)}
-                style={{ height: '47px' }}
+            <button
+                className={styles[initial === 'cross' ? 'selected' : '']}
+                onClick={() => handleConfirm('cross')}
             >
-                Confirm
-            </SimpleButton>
+                <h3>Cross Margin</h3>
+                <p>
+                    All cross positions share the same cross margin as
+                    collateral. In the event of liquidation, your cross margin
+                    balance and any remaining open positions under assets in
+                    this mode may be forfeited.
+                </p>
+            </button>
+            <button
+                className={styles[initial === 'isolated' ? 'selected' : '']}
+                onClick={() => handleConfirm('isolated')}
+            >
+                <h3>Isolated Mode</h3>
+                <p>
+                    Manage your risk on individual positions by restricting the
+                    amount of margin allocated to each. If the margin ratio of
+                    an isolated position reaches 100%, the position will be
+                    liquidated. Margin can be added or removed to individual
+                    positions in this mode.
+                </p>
+            </button>
         </section>
     );
 }

--- a/packages/frontend/app/components/Trade/OrderInput/OrderInput.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderInput.tsx
@@ -21,7 +21,7 @@ import {
     useNotificationStore,
     type NotificationStoreIF,
 } from '~/stores/NotificationStore';
-import { useTradeDataStore, type marginModesT } from '~/stores/TradeDataStore';
+import { useTradeDataStore } from '~/stores/TradeDataStore';
 import type { OrderBookMode } from '~/utils/orderbook/OrderBookIFs';
 import { parseNum } from '~/utils/orderbook/OrderBookUtils';
 import evenSvg from '../../../assets/icons/EvenPriceDistribution.svg';
@@ -35,7 +35,6 @@ import PlaceOrderButtons from './PlaceOrderButtons/PlaceOrderButtons';
 import PositionSize from './PositionSIze/PositionSize';
 import PriceInput from './PriceInput/PriceInput';
 import PriceRange from './PriceRange/PriceRange';
-// import ReduceAndProfitToggle from './ReduceAndProfitToggle/ReduceAndProfitToggle';
 import { type MarginBucketInfo } from '@crocswap-libs/ambient-ember';
 import SimpleButton from '~/components/SimpleButton/SimpleButton';
 import RunningTime from './RunningTime/RunningTime';
@@ -875,13 +874,9 @@ function OrderInput({
                             {confirmOrderModal.content === 'margin' && (
                                 <MarginModal
                                     initial={marginMode}
-                                    handleConfirm={(m: marginModesT): void => {
-                                        setMarginMode(m);
-                                        confirmOrderModal.close();
-                                    }}
+                                    handleConfirm={setMarginMode}
                                 />
                             )}
-
                             {confirmOrderModal.content === 'scale' && (
                                 <ScaleOrders
                                     totalQuantity={parseFloat(


### PR DESCRIPTION
Remove the CTA button in the Margin Mode modal. Clicking one of the two options will directly set state. The modal must be dismissed as a second user action (outside click, `X` click, <kbd>Esc</kbd> keypress).