### PR TITLE
improve sliders interactions

### DIFF
--- a/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.tsx
@@ -106,6 +106,10 @@ export default function LeverageSlider({
 
     const sliderRef = useRef<HTMLDivElement>(null);
     const knobRef = useRef<HTMLDivElement>(null);
+    const currentValueRef = useRef<number>(currentValue);
+    useEffect(() => {
+        currentValueRef.current = currentValue;
+    }, [currentValue]);
 
     // Helper function to get the actual rounded value (what user sees)
     const getRoundedDisplayValue = (val: number): number => {
@@ -325,7 +329,7 @@ export default function LeverageSlider({
 
     // Get position for the knob as percentage
     const getKnobPosition = (): number => {
-        if (isNaN(currentValue)) {
+        if (isNaN(currentValue) || !isFinite(currentValue)) {
             return 0;
         }
         return valueToPercentage(currentValue);
@@ -334,6 +338,10 @@ export default function LeverageSlider({
     // Get color based on position
     const getColorAtPosition = (position: number): string => {
         const colorStops = SLIDER_CONFIG.COLOR_STOPS;
+        // Safety check for NaN or invalid values
+        if (isNaN(position) || !isFinite(position)) {
+            return colorStops[0].color; // Return default color (teal)
+        }
 
         // Ensure position is between 0 and 100
         const boundedPosition = Math.max(0, Math.min(100, position));
@@ -430,16 +438,11 @@ export default function LeverageSlider({
         setHoverValue(null);
         setHoveredTickIndex(null);
     };
-
-    // Handle track click to set value
-    const handleTrackClick = (e: React.MouseEvent) => {
-        if (!sliderRef.current) return;
+    const calculateValueFromPosition = (clientX: number): number => {
+        if (!sliderRef.current) return currentValue;
 
         const rect = sliderRef.current.getBoundingClientRect();
-        const offsetX = Math.max(
-            0,
-            Math.min(e.clientX - rect.left, rect.width),
-        );
+        const offsetX = Math.max(0, Math.min(clientX - rect.left, rect.width));
 
         // Account for knob margins when calculating percentage
         const knobRadius = SLIDER_CONFIG.KNOB_RADIUS;
@@ -451,16 +454,45 @@ export default function LeverageSlider({
             ((adjustedOffsetX - knobRadius) / (rect.width - 2 * knobRadius)) *
             100;
 
-        // Convert percentage to value (no rounding for smooth movement)
+        // Convert percentage to value
         const newValue = percentageToValue(percentage);
 
         // Ensure value is within min/max bounds
-        const boundedValue = constrainValue(newValue);
+        return constrainValue(newValue);
+    };
 
-        // Use the exact value for clicks (no rounding)
+    // Handle track click to set value
+    const handleTrackClick = (e: React.MouseEvent) => {
+        const boundedValue = calculateValueFromPosition(e.clientX);
         handleLeverageChange(boundedValue);
     };
 
+    const handleTrackTouchStart = (e: React.TouchEvent) => {
+        if ((e.target as HTMLElement).closest(`.${styles.sliderKnob}`)) {
+            return;
+        }
+
+        if (!e.touches[0]) return;
+
+        const boundedValue = calculateValueFromPosition(e.touches[0].clientX);
+        handleLeverageChange(boundedValue);
+        setIsDragging(true);
+        e.preventDefault();
+    };
+
+    const handleTrackMouseDown = (e: React.MouseEvent) => {
+        // Don't interfere if clicking on the knob
+        if ((e.target as HTMLElement).closest(`.${styles.sliderKnob}`)) {
+            return;
+        }
+
+        // Handle the click first
+        handleTrackClick(e);
+
+        // Then set up for potential dragging
+        setIsDragging(true);
+        e.preventDefault();
+    };
     // Handle dragging functionality
     useEffect(() => {
         const handleMouseMove = (e: MouseEvent) => {
@@ -530,7 +562,7 @@ export default function LeverageSlider({
         const handleMouseUp = () => {
             if (isDragging && !modalMode) {
                 // Keep the exact value when dragging ends (no rounding/snapping)
-                setPreferredLeverage(currentValue);
+                setPreferredLeverage(currentValueRef.current);
             }
             setIsDragging(false);
         };
@@ -538,7 +570,7 @@ export default function LeverageSlider({
         const handleTouchEnd = () => {
             if (isDragging && !modalMode) {
                 // Keep the exact value when dragging ends (no rounding/snapping)
-                setPreferredLeverage(currentValue);
+                setPreferredLeverage(currentValueRef.current);
             }
             setIsDragging(false);
         };
@@ -568,7 +600,7 @@ export default function LeverageSlider({
         isDragging,
         minimumInputValue,
         maximumInputValue,
-        currentValue,
+        // currentValue,
         modalMode,
     ]);
 
@@ -661,7 +693,8 @@ export default function LeverageSlider({
                     <div
                         ref={sliderRef}
                         className={styles.sliderTrack}
-                        onClick={handleTrackClick}
+                        onMouseDown={handleTrackMouseDown}
+                        onTouchStart={handleTrackTouchStart}
                         onMouseMove={handleTrackMouseMove}
                         onMouseLeave={handleTrackMouseLeave}
                     >
@@ -674,7 +707,10 @@ export default function LeverageSlider({
                             style={{
                                 width: `${getKnobPosition()}%`,
                                 background: createGradientString(),
-                                backgroundSize: `${100 / (getKnobPosition() / 100)}% 100%`,
+                                backgroundSize:
+                                    getKnobPosition() > 0
+                                        ? `${100 / (getKnobPosition() / 100)}% 100%`
+                                        : '100% 100%',
                                 backgroundPosition: 'left center',
                             }}
                         ></div>
@@ -763,9 +799,10 @@ export default function LeverageSlider({
                                                 ? tickColor
                                                 : UI_CONFIG.INACTIVE_LABEL_COLOR,
                                     }}
-                                    onClick={() =>
-                                        handleLeverageChange(tickValue)
-                                    }
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleLeverageChange(tickValue);
+                                    }}
                                     onMouseEnter={() => handleTickHover(index)}
                                     onMouseLeave={handleTickLeave}
                                 >
@@ -791,7 +828,8 @@ export default function LeverageSlider({
                     <div
                         ref={sliderRef}
                         className={styles.sliderTrack}
-                        onClick={handleTrackClick}
+                        onMouseDown={handleTrackMouseDown}
+                        onTouchStart={handleTrackTouchStart}
                         onMouseMove={handleTrackMouseMove}
                         onMouseLeave={handleTrackMouseLeave}
                     >
@@ -804,7 +842,11 @@ export default function LeverageSlider({
                             style={{
                                 width: `${getKnobPosition()}%`,
                                 background: createGradientString(),
-                                backgroundSize: `${100 / (getKnobPosition() / 100)}% 100%`,
+                                backgroundSize:
+                                    getKnobPosition() > 0
+                                        ? `${100 / (getKnobPosition() / 100)}% 100%`
+                                        : '100% 100%',
+
                                 backgroundPosition: 'left center',
                             }}
                         ></div>
@@ -849,6 +891,10 @@ export default function LeverageSlider({
                                     }}
                                     onMouseEnter={() => handleTickHover(index)}
                                     onMouseLeave={handleTickLeave}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleLeverageChange(tickValue);
+                                    }}
                                 ></div>
                             );
                         })}

--- a/packages/frontend/app/components/Trade/OrderInput/PositionSIze/PositionSize.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/PositionSIze/PositionSize.tsx
@@ -52,6 +52,10 @@ export default function PositionSize({
 
     const sliderRef = useRef<HTMLDivElement>(null);
     const knobRef = useRef<HTMLDivElement>(null);
+    const currentValueRef = useRef<number>(currentValue);
+    useEffect(() => {
+        currentValueRef.current = currentValue;
+    }, [currentValue]);
 
     // Update internal value when prop changes (but not during drag)
     useEffect(() => {
@@ -139,7 +143,7 @@ export default function PositionSize({
             document.removeEventListener('touchend', handleTouchEnd);
             document.removeEventListener('touchcancel', handleTouchEnd);
         };
-    }, [isDragging, onChange]);
+    }, [isDragging]);
 
     const handleKnobMouseDown = (e: React.MouseEvent | React.TouchEvent) => {
         (e.target as HTMLElement).focus();
@@ -169,7 +173,48 @@ export default function PositionSize({
         setCurrentValue(snappedValue);
         onChange(snappedValue);
     };
+    const handleTrackTouchStart = (e: React.TouchEvent) => {
+        if ((e.target as HTMLElement).closest(`.${styles.sliderKnob}`)) {
+            return;
+        }
 
+        if (!e.touches[0]) return;
+
+        // Get the percentage directly from touch position
+        const percentage = getPercentageFromPosition(e.touches[0].clientX);
+
+        let snappedValue = percentage;
+
+        // Check for marker snapping (same logic as handleTrackClick)
+        POSITION_SIZE_CONFIG.VISUAL_MARKERS.forEach((marker) => {
+            const distance = Math.abs(marker.value - percentage);
+            if (distance <= POSITION_SIZE_CONFIG.MARKER_SNAP_TOLERANCE) {
+                snappedValue = marker.value;
+            }
+        });
+
+        snappedValue = Math.min(
+            POSITION_SIZE_CONFIG.MAX_VALUE,
+            Math.max(POSITION_SIZE_CONFIG.MIN_VALUE, snappedValue),
+        );
+
+        setCurrentValue(snappedValue);
+        onChange(snappedValue);
+        setIsDragging(true);
+        e.preventDefault();
+    };
+    const handleTrackMouseDown = (e: React.MouseEvent) => {
+        // Don't interfere if clicking on the knob
+        if ((e.target as HTMLElement).closest(`.${styles.sliderKnob}`)) {
+            return;
+        }
+
+        // Handle the click first
+        handleTrackClick(e);
+
+        setIsDragging(true);
+        e.preventDefault();
+    };
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const rawValue = e.target.value.replace(/[^\d]/g, ''); // Remove non-numeric
         const newValue = parseInt(rawValue);
@@ -212,7 +257,8 @@ export default function PositionSize({
                     <div
                         ref={sliderRef}
                         className={styles.sliderTrack}
-                        onClick={handleTrackClick}
+                        onMouseDown={handleTrackMouseDown}
+                        onTouchStart={handleTrackTouchStart}
                     >
                         {/* Gray background track */}
                         <div className={styles.sliderBackground}></div>


### PR DESCRIPTION
1. Fixed Click-and-Drag Interaction Bug
Issue:
When users clicked on the slider track and then attempted to drag, the slider would not respond during the drag but would only update when the mouse was released.
Cause: 
The track used onClick event, which only set isDragging = false after you are finished. Anything else was ignored because the  state was never activated.
Fix:
Replaced onClick with onMouseDown on slider track
Added handleTrackMouseDown and handleTrackTouchStart functions that handles the initial clicking and dragging

2. Fixed Memory Leak in Drag Event Listeners
Issue:
The drag handling useEffect hasd the  currentValue in its dependency array, causing the effect to re-run on every value change during dragging.
Fix:
Added currentValueRef to track the current value via ref
Added useEffect to keep the ref updated.
Updated handleMouseUp and handleTouchEnd to use currentValueRef.current instead of currentValue
Removed currentValue from the drag useEffect dependency array.

3. Added Safety Checks for NAN Edge Cases
Issue: This is not really an issue because our slide never goes to zero but I figured we might as well make the change. A bug from this would mostly only affect css.
Fixes:
Updated gradient background calculation to handle when getKnobPosition() returns 0 and I added safety checks in getKnobPosition() and getColorAtPosition() to handle NaN/infinite values.

All relevant fixes were also applied to Position slider

4. Improved Event Handling Consistency
Issue: 
Click events on tick marks could bubble up and interfere with track interactions.
Fix:
Added e.stopPropagation() to tick mark click handlers in modal mode
