### PR TITLE
Change all tooltips svgs to lucid svgs

### DIFF
--- a/packages/frontend/app/components/PageHeader/DropdownMenu/DropdownMenu.tsx
+++ b/packages/frontend/app/components/PageHeader/DropdownMenu/DropdownMenu.tsx
@@ -18,7 +18,7 @@ const menuItems = [
     // { name: 'Medium', icon: <FaMediumM /> },
     // { name: 'Privacy', icon: <FaUserSecret /> },
     // { name: 'Terms of Service', icon: <FaFileAlt /> },
-    // { name: 'FAQ', icon: <FaQuestionCircle /> },
+    // { name: 'FAQ', icon: <LuCircleHelp /> },
 ];
 
 interface DropdownMenuProps {

--- a/packages/frontend/app/components/PageHeader/PageHeader.tsx
+++ b/packages/frontend/app/components/PageHeader/PageHeader.tsx
@@ -4,7 +4,6 @@ import {
     useSession,
 } from '@fogo/sessions-sdk-react';
 import { useEffect, useState } from 'react';
-// import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import {
     DFLT_EMBER_MARKET,
     getUserMarginBucket,
@@ -308,7 +307,7 @@ export default function PageHeader() {
                                 setIsHelpDropdownOpen(!isHelpDropdownOpen)
                             }
                         >
-                            <AiOutlineQuestionCircle
+                            <LuCircleHelp
                                 size={18}
                                 color='var(--text2)'
                             />

--- a/packages/frontend/app/components/Portfolio/PortfolioDeposit/PortfolioDeposit.tsx
+++ b/packages/frontend/app/components/Portfolio/PortfolioDeposit/PortfolioDeposit.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, memo, useMemo } from 'react';
 import styles from './PortfolioDeposit.module.css';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { useDebouncedCallback } from '~/hooks/useDebounce';
 import TokenDropdown, {
     AVAILABLE_TOKENS,
@@ -11,6 +10,7 @@ import SimpleButton from '~/components/SimpleButton/SimpleButton';
 import FogoLogo from '../../../assets/tokens/FOGO.svg';
 import { useNotificationStore } from '~/stores/NotificationStore';
 import useNumFormatter from '~/hooks/useNumFormatter';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface propsIF {
     portfolio: {
@@ -278,7 +278,7 @@ function PortfolioDeposit(props: propsIF) {
                                     content={info?.tooltip}
                                     position='right'
                                 >
-                                    <AiOutlineQuestionCircle size={13} />
+                                    <LuCircleHelp size={12} />
                                 </Tooltip>
                             )}
                         </div>

--- a/packages/frontend/app/components/Portfolio/PortfolioSend/PortfolioSend.tsx
+++ b/packages/frontend/app/components/Portfolio/PortfolioSend/PortfolioSend.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, memo, useMemo } from 'react';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import Tooltip from '~/components/Tooltip/Tooltip';
 import styles from './PortfolioSend.module.css';
 import { useDebouncedCallback } from '~/hooks/useDebounce';
@@ -8,6 +7,7 @@ import TokenDropdown, {
     type Token,
 } from '~/components/TokenDropdown/TokenDropdown';
 import SimpleButton from '~/components/SimpleButton/SimpleButton';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface PortfolioSendProps {
     availableAmount: number;
@@ -226,7 +226,7 @@ function PortfolioSend({
                                     content={info?.tooltip}
                                     position='right'
                                 >
-                                    <AiOutlineQuestionCircle size={13} />
+                                    <LuCircleHelp size={12} />
                                 </Tooltip>
                             )}
                         </div>

--- a/packages/frontend/app/components/Portfolio/PortfolioWithdraw/PortfolioWithdraw.tsx
+++ b/packages/frontend/app/components/Portfolio/PortfolioWithdraw/PortfolioWithdraw.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback, useMemo, useState } from 'react';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import Tooltip from '~/components/Tooltip/Tooltip';
 import { useDebouncedCallback } from '~/hooks/useDebounce';
 import styles from './PortfolioWithdraw.module.css';
@@ -265,7 +264,7 @@ function PortfolioWithdraw({
                                     content={info?.tooltip}
                                     position='right'
                                 >
-                                    <AiOutlineQuestionCircle size={13} />
+                                    <LuCircleHelp size={12} />
                                 </Tooltip>
                             )}
                         </div>

--- a/packages/frontend/app/components/Tooltip/Tooltip.module.css
+++ b/packages/frontend/app/components/Tooltip/Tooltip.module.css
@@ -85,6 +85,7 @@
     visibility: hidden;
     pointer-events: none;
 }
+
 @keyframes fadeIn {
     from {
         opacity: 0;

--- a/packages/frontend/app/components/Trade/LeverageSliderModal/LeverageSliderModal.tsx
+++ b/packages/frontend/app/components/Trade/LeverageSliderModal/LeverageSliderModal.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import styles from './LeverageSliderModal.module.css';
 import Modal from '~/components/Modal/Modal';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { BsQuestionCircle } from 'react-icons/bs';
 import SimpleButton from '~/components/SimpleButton/SimpleButton';
 import LeverageSlider from '../OrderInput/LeverageSlider/LeverageSlider';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface LeverageSliderModalProps {
     currentLeverage: number;
@@ -50,7 +50,7 @@ export default function LeverageSliderModal({
                             content='max position at current level'
                             position='right'
                         >
-                            <BsQuestionCircle size={12} />
+                            <LuCircleHelp size={12} />
                         </Tooltip>
                     </p>
                     <span>100,000 USD</span>

--- a/packages/frontend/app/components/Trade/OrderInput/ChaseDistance/ChaseDistance.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/ChaseDistance/ChaseDistance.tsx
@@ -3,8 +3,8 @@ import ComboBox from '~/components/Inputs/ComboBox/ComboBox';
 import NumFormattedInput from '~/components/Inputs/NumFormattedInput/NumFormattedInput';
 import styles from './ChaseDistance.module.css';
 import type { OrderBookMode } from '~/utils/orderbook/OrderBookIFs';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import Tooltip from '~/components/Tooltip/Tooltip';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface PropsIF {
     value: string;
@@ -71,7 +71,7 @@ const ChaseDistance: React.FC<PropsIF> = React.memo((props) => {
                 <div className={styles.detailLabel}>
                     <span>Max Bid</span>
                     <Tooltip content={'max bid explanation'} position='right'>
-                        <AiOutlineQuestionCircle size={13} />
+                        <LuCircleHelp size={12} />
                     </Tooltip>
                 </div>
                 <span className={styles.detailValue}>5.932</span>

--- a/packages/frontend/app/components/Trade/OrderInput/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/ConfirmationModal/ConfirmationModal.tsx
@@ -1,9 +1,9 @@
 import styles from './ConfirmationModal.module.css';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import ToggleSwitch from '../../ToggleSwitch/ToggleSwitch';
 import type { modalContentT } from '../OrderInput';
 import { useAppSettings } from '~/stores/AppSettingsStore';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface propsIF {
     tx: modalContentT;
@@ -92,7 +92,7 @@ export default function ConfirmationModal(props: propsIF) {
                                     content={info?.tooltip}
                                     position='right'
                                 >
-                                    <AiOutlineQuestionCircle size={13} />
+                                    <LuCircleHelp size={12} />
                                 </Tooltip>
                             )}
                         </div>

--- a/packages/frontend/app/components/Trade/OrderInput/OrderDetails/OrderDetails.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderDetails/OrderDetails.tsx
@@ -1,11 +1,11 @@
 import { motion } from 'framer-motion';
 import React, { useMemo } from 'react';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { HiOutlineChevronDoubleDown } from 'react-icons/hi2';
 import Tooltip from '~/components/Tooltip/Tooltip';
 import useNumFormatter from '~/hooks/useNumFormatter';
 import { useTradeDataStore } from '~/stores/TradeDataStore';
 import styles from './OrderDetails.module.css';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface MarketInfoItem {
     label: string;
@@ -184,7 +184,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
                                         content={data.tooltipLabel}
                                         position='right'
                                     >
-                                        <AiOutlineQuestionCircle size={13} />
+                                        <LuCircleHelp size={12} />
                                     </Tooltip>
                                 </div>
                                 <span className={styles.detail_value}>

--- a/packages/frontend/app/components/Trade/OrderInput/OrderInput.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderInput.tsx
@@ -12,7 +12,6 @@ import React, {
     useState,
     type JSX,
 } from 'react';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { GoZap } from 'react-icons/go';
 import { MdKeyboardArrowLeft } from 'react-icons/md';
 import { PiSquaresFour } from 'react-icons/pi';
@@ -50,6 +49,7 @@ import ScaleOrders from './ScaleOrders/ScaleOrders';
 import SizeInput from './SizeInput/SizeInput';
 import StopPrice from './StopPrice/StopPrice';
 import TradeDirection from './TradeDirection/TradeDirection';
+import { LuCircleHelp } from 'react-icons/lu';
 export interface OrderTypeOption {
     value: string;
     label: string;
@@ -790,7 +790,7 @@ function OrderInput({
                             content={'price distribution'}
                             position='right'
                         >
-                            <AiOutlineQuestionCircle size={13} />
+                            <LuCircleHelp size={12} />
                         </Tooltip>
                     </div>
                     <div className={styles.actionButtonsContainer}>
@@ -1217,9 +1217,7 @@ function OrderInput({
                                             content={data?.tooltipLabel}
                                             position='right'
                                         >
-                                            <AiOutlineQuestionCircle
-                                                size={13}
-                                            />
+                                            <LuCircleHelp size={12} />
                                         </Tooltip>
                                     </div>
                                     <span className={styles.inputDetailValue}>

--- a/packages/frontend/app/components/Trade/OrderInput/ReduceAndProfitToggle/ReduceAndProfitToggle.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/ReduceAndProfitToggle/ReduceAndProfitToggle.tsx
@@ -1,10 +1,10 @@
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import ToggleSwitch from '../../ToggleSwitch/ToggleSwitch';
 import styles from './ReduceAndProfitToggle.module.css';
 import Tooltip from '~/components/Tooltip/Tooltip';
 import { useState } from 'react';
 import { BsChevronDown } from 'react-icons/bs';
 import ChaseDistance from '../ChaseDistance/ChaseDistance';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface PropsIF {
     isReduceOnlyEnabled: boolean;
@@ -155,7 +155,7 @@ export default function ReduceAndProfitToggle(props: PropsIF) {
                 <div className={styles.inputDetailsLabel}>
                     <span>Chasing Interval</span>
                     <Tooltip content={'chasing interval'} position='right'>
-                        <AiOutlineQuestionCircle size={13} />
+                        <LuCircleHelp size={12} />
                     </Tooltip>
                 </div>
                 <span className={styles.inputDetailValue}>Atomic</span>

--- a/packages/frontend/app/components/Trade/OrderInput/ScaleOrders/DistributionDropdown.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/ScaleOrders/DistributionDropdown.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { FaChevronDown } from 'react-icons/fa';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import Tooltip from '~/components/Tooltip/Tooltip';
 import SVGIcon from '~/components/SvgIcon/SvgIcon';
 import useOutsideClick from '~/hooks/useOutsideClick';
 import styles from './ScaleOrders.module.css';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface DistributionOption<T extends string> {
     type: T;
@@ -47,7 +47,7 @@ export default function DistributionDropdown<T extends string>({
             <span className={styles.optionHeader}>
                 {label}
                 <Tooltip content={tooltipContent} position='right'>
-                    <AiOutlineQuestionCircle size={13} />
+                    <LuCircleHelp size={12} />
                 </Tooltip>
             </span>
 

--- a/packages/frontend/app/components/Vault/DepositModal/DepositModal.tsx
+++ b/packages/frontend/app/components/Vault/DepositModal/DepositModal.tsx
@@ -1,8 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import styles from './DepositModal.module.css';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
-import { LuChevronDown } from 'react-icons/lu';
+import { LuChevronDown, LuCircleHelp } from 'react-icons/lu';
 import { useVaultManager } from '~/routes/vaults/useVaultManager';
 import { useDepositService } from '~/hooks/useDepositService';
 import { useNotificationStore } from '~/stores/NotificationStore';
@@ -309,7 +308,7 @@ export default function DepositModal({
                                     content={info?.tooltip}
                                     position='right'
                                 >
-                                    <AiOutlineQuestionCircle size={13} />
+                                    <LuCircleHelp size={12} />
                                 </Tooltip>
                             )}
                         </div>

--- a/packages/frontend/app/components/Vault/WithdrawModal/WithdrawModal.tsx
+++ b/packages/frontend/app/components/Vault/WithdrawModal/WithdrawModal.tsx
@@ -1,9 +1,9 @@
 import { useState, useCallback } from 'react';
 import styles from './WithdrawModal.module.css';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { useVaultManager } from '~/routes/vaults/useVaultManager';
 import FogoLogo from '../../../assets/tokens/FOGO.svg';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface WithdrawModalProps {
     vault: {
@@ -120,7 +120,7 @@ export default function WithdrawModal({
                                     content={info?.tooltip}
                                     position='right'
                                 >
-                                    <AiOutlineQuestionCircle size={13} />
+                                    <LuCircleHelp size={12} />
                                 </Tooltip>
                             )}
                         </div>

--- a/packages/frontend/app/css/index.css
+++ b/packages/frontend/app/css/index.css
@@ -251,6 +251,14 @@ svg {
     max-width: 100%;
 }
 
+svg {
+    shape-rendering: crispEdges;
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
+    image-rendering: pixelated;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+}
 input,
 button,
 textarea,

--- a/packages/frontend/app/routes/trade/symbol/symbolinfofield/symbolinfofield.tsx
+++ b/packages/frontend/app/routes/trade/symbol/symbolinfofield/symbolinfofield.tsx
@@ -4,7 +4,7 @@ import styles from './symbolinfofield.module.css';
 import { motion } from 'framer-motion';
 import SkeletonNode from '~/components/Skeletons/SkeletonNode/SkeletonNode';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
+import { LuCircleHelp } from 'react-icons/lu';
 
 interface SymbolInfoFieldProps {
     label: string;
@@ -85,7 +85,7 @@ const SymbolInfoField: React.FC<SymbolInfoFieldProps> = ({
                     {tooltipContent && (
                         <div className={styles.tooltip}>
                             <Tooltip content={tooltipContent} position='right'>
-                                <AiOutlineQuestionCircle size={13} />
+                                <LuCircleHelp size={12} />
                             </Tooltip>
                         </div>
                     )}


### PR DESCRIPTION
Certain svgs seem blurry and less sharp on smaller screens. The highest quality in svg library is Lucide.
All tooltip icon svgs should now be using the lucid versions.