### PR TITLE
Fix  candle and volume colors not match

### DIFF
--- a/packages/frontend/app/contexts/TradingviewContext.tsx
+++ b/packages/frontend/app/contexts/TradingviewContext.tsx
@@ -136,18 +136,20 @@ export const TradingViewProvider: React.FC<{
             });
 
             if (chart) {
-                const volumeStudyId = chart
+                const volumeStudies = chart
                     .activeChart()
                     .getAllStudies()
-                    .find((x) => x.name === 'Volume');
+                    .filter((x) => x.name === 'Volume');
 
-                if (volumeStudyId) {
-                    const volume = chart
-                        .activeChart()
-                        .getStudyById(volumeStudyId.id);
-                    volume.applyOverrides({
-                        'volume.color.0': c.sell,
-                        'volume.color.1': c.buy,
+                if (volumeStudies) {
+                    volumeStudies.forEach((item) => {
+                        const volume = chart
+                            .activeChart()
+                            .getStudyById(item.id);
+                        volume.applyOverrides({
+                            'volume.color.0': c.sell,
+                            'volume.color.1': c.buy,
+                        });
                     });
                 }
             }

--- a/packages/frontend/app/contexts/TradingviewContext.tsx
+++ b/packages/frontend/app/contexts/TradingviewContext.tsx
@@ -146,8 +146,8 @@ export const TradingViewProvider: React.FC<{
                         .activeChart()
                         .getStudyById(volumeStudyId.id);
                     volume.applyOverrides({
-                        'volume.color.0': c.buy,
-                        'volume.color.1': c.sell,
+                        'volume.color.0': c.sell,
+                        'volume.color.1': c.buy,
                     });
                 }
             }

--- a/packages/frontend/app/contexts/TradingviewContext.tsx
+++ b/packages/frontend/app/contexts/TradingviewContext.tsx
@@ -193,6 +193,16 @@ export const TradingViewProvider: React.FC<{
                 saveChartLayout(chart);
                 showBuysSellsOnChart && chart.chart().refreshMarks();
             });
+
+            chart.subscribe('study_event', (studyId) => {
+                const studyElement = chart.activeChart().getStudyById(studyId);
+
+                const colors = getBsColor();
+                studyElement.applyOverrides({
+                    'volume.color.0': colors.sell,
+                    'volume.color.1': colors.buy,
+                });
+            });
         }
     }, [chart]);
 


### PR DESCRIPTION
- fixed : candle and volume colors not match

- fixed : apply volume color overrides to all volume studies

- fixed : volume color not correct show when create new volume indicator

**Testing Steps:**

**1. ****New volume study:******

Add a new volume indicator after the chart has loaded. Previously, it would be initialized with default colors. Now it should adopt the correct theme colors immediately.

**2. Multiple volume studies with theme change:**

1. Add multiple volume indicators to the chart.
2. Change the application theme 
3. Ensure all volume indicators update their colors correctly, not just one.
