### PR TITLE
add min leverage workflow

### DIFF
--- a/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.module.css
+++ b/packages/frontend/app/components/Trade/OrderInput/LeverageSlider/LeverageSlider.module.css
@@ -9,7 +9,34 @@
     color: var(--text2, #bcbcc4);
     font-size: var(--font-size-s, 12px);
 }
+.titleWithWarning {
+    position: relative;
+}
 
+.minimumWarning {
+    position: absolute;
+    top: 100%;
+    left: 0;
+
+    background-color: rgba(239, 83, 80, 0.1);
+    color: var(--red);
+    font-size: var(--font-size-s, 12px);
+    white-space: nowrap;
+    z-index: 10;
+    /* Optional: Add a subtle animation */
+    animation: fadeIn 0.2s ease-in-out;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
 .sliderWithValue {
     display: flex;
     align-items: center;

--- a/packages/frontend/app/components/Trade/OrderInput/OrderInput.tsx
+++ b/packages/frontend/app/components/Trade/OrderInput/OrderInput.tsx
@@ -841,6 +841,7 @@ function OrderInput({
             onChange: handleLeverageChange,
             minNotionalUsdOrderSize: minNotionalUsdOrderSize,
             generateRandomMaximumInput: generateRandomMaximumInput,
+            minimumValue: 5,
         }),
         [leverage, handleLeverageChange],
     );


### PR DESCRIPTION
Added a min leverage prop to the leverage sliders.
Added functionality to slider to stop user dragging or clicking below minimum leverage.
Added a warning message when the slider is at the minimum leverage.

Question:
Should the warning message show at the minimum leverage or only after the user attempts to go below the minimum leverage.

Minimum leverage is currently hardcoded as 5 in OrderInput.tsx for demonstration purposes