### PR TITLE
Websocket | Backdoor for User based channels

### DIFF
--- a/packages/frontend/app/hooks/useSdk.tsx
+++ b/packages/frontend/app/hooks/useSdk.tsx
@@ -107,14 +107,6 @@ export const SdkProvider: React.FC<{
     }, [internetConnected]);
 
     const stashSubscriptions = useCallback(() => {
-        // Market data channels that can be stashed
-        const MARKET_CHANNELS = new Set([
-            'l2Book',
-            'trades',
-            'candle',
-            'allMids',
-        ]);
-
         if (info?.multiSocketInfo) {
             const activeSubs =
                 info?.multiSocketInfo?.getActiveSubscriptions() || {};
@@ -123,17 +115,9 @@ export const SdkProvider: React.FC<{
                 // reset stashed subs if we can access active subs from ws object
                 stashedSubs.current = {};
             }
-
             Object.keys(activeSubs).forEach((key) => {
-                const channelType = key.split(':')[0];
-                // Only stash market data subscriptions
-                if (MARKET_CHANNELS.has(channelType)) {
-                    const subs = activeSubs[key];
-                    stashedSubs.current[key] = subs;
-                    console.log(`>>> stashing market subscription: ${key}`);
-                } else {
-                    console.log(`>>> keeping active user subscription: ${key}`);
-                }
+                const subs = activeSubs[key];
+                stashedSubs.current[key] = subs;
             });
         } else {
             const activeSubs = info?.wsManager?.getActiveSubscriptions() || {};
@@ -144,15 +128,8 @@ export const SdkProvider: React.FC<{
             }
 
             Object.keys(activeSubs).forEach((key) => {
-                const channelType = key.split(':')[0];
-                // Only stash market data subscriptions
-                if (MARKET_CHANNELS.has(channelType)) {
-                    const subs = activeSubs[key];
-                    stashedSubs.current[key] = subs;
-                    console.log(`>>> stashing market subscription: ${key}`);
-                } else {
-                    console.log(`>>> keeping active user subscription: ${key}`);
-                }
+                const subs = activeSubs[key];
+                stashedSubs.current[key] = subs;
             });
         }
         console.log(

--- a/packages/frontend/app/hooks/useSdk.tsx
+++ b/packages/frontend/app/hooks/useSdk.tsx
@@ -141,13 +141,7 @@ export const SdkProvider: React.FC<{
 
     const stashWebsocket = useCallback(() => {
         if (info?.multiSocketInfo) {
-            // Only stop market socket, keep user socket alive for orders/fills
-            const pool = info.multiSocketInfo.getPool();
-            console.log(
-                '>>> Stopping only market socket, keeping user socket active',
-            );
-            pool.stopSocket('market');
-            // Note: We're NOT stopping the user socket to maintain order/fill subscriptions
+            info.multiSocketInfo.stop();
         } else {
             info?.wsManager?.stop();
         }
@@ -157,25 +151,8 @@ export const SdkProvider: React.FC<{
         if (!isClient) return;
 
         if (info?.multiSocketInfo) {
-            // For multi-socket, only reinit market socket since user socket stayed active
-            const pool = info.multiSocketInfo.getPool();
-            console.log('>>> Reinitializing market socket only');
-
-            // Filter stashed subs to only include market-related subscriptions
-            const marketSubs: Record<string, any> = {};
-            Object.entries(stashedSubs.current).forEach(([key, value]) => {
-                const channelType = key.split(':')[0];
-                // Only restore market data subscriptions
-                if (
-                    ['l2Book', 'trades', 'candle', 'allMids'].includes(
-                        channelType,
-                    )
-                ) {
-                    marketSubs[key] = value;
-                }
-            });
-
-            pool.reInit(marketSubs);
+            // re-init subs
+            info.multiSocketInfo?.getPool().reInit(stashedSubs.current);
         } else {
             info?.wsManager?.reInit(stashedSubs.current);
         }


### PR DESCRIPTION
Backdoor has been added into websocket-instance to get channel name without parsing message to check if a message is required for updating user data.
That mechanism is working on sleep mode,


Allowed channels;
- userFills ( Trade history)
- userHistoricalOrders (Order History)
- webData2 (Open Orders and Positions)
- _userTwapSliceFills (Twap data no need for now)_
- _userTwapHistory (Twap data no need for now)_

That channels can be managed in code (line: 31)
`websocket-instance.ts`

`const WsBackdoorChannelsForSleepMode = new Set([
    'userFills',
    'userHistoricalOrders',
    'userTwapSliceFills',
    'userTwapHistory',
    'webData2',
]);
`

Also preventing user channels from stashing has been reverted, because we are using that stash mechanism to open subscriptions again if ws connection is dropped (so its not about processing messages)
