### PR TITLE
fix: order side was incorrect when repositioned in a different theme

### DIFF
--- a/packages/frontend/app/routes/chart/orders/component/LabelComponent.ts
+++ b/packages/frontend/app/routes/chart/orders/component/LabelComponent.ts
@@ -479,7 +479,8 @@ const LabelComponent = ({
             if (
                 !tempSelectedLine ||
                 originalPrice === undefined ||
-                tempSelectedLine.parentLine.oid === undefined
+                tempSelectedLine.parentLine.oid === undefined ||
+                tempSelectedLine.parentLine.side === undefined
             ) {
                 return;
             }
@@ -487,10 +488,7 @@ const LabelComponent = ({
             const orderId = tempSelectedLine.parentLine.oid;
             const newPrice = tempSelectedLine.parentLine.yPrice;
             const quantity = tempSelectedLine.parentLine.quantityTextValue;
-            const side =
-                tempSelectedLine.parentLine.color === '#EF5350'
-                    ? 'sell'
-                    : 'buy';
+            const side = tempSelectedLine.parentLine.side;
 
             try {
                 // If cancel was successful, create a new order with the updated price

--- a/packages/frontend/app/routes/chart/orders/component/LineComponent.ts
+++ b/packages/frontend/app/routes/chart/orders/component/LineComponent.ts
@@ -16,6 +16,7 @@ export type LineData = {
     oid?: number;
     lineStyle: number;
     lineWidth: number;
+    side?: 'buy' | 'sell';
 };
 
 interface LineProps {

--- a/packages/frontend/app/routes/chart/orders/useOpenOrderLines.ts
+++ b/packages/frontend/app/routes/chart/orders/useOpenOrderLines.ts
@@ -108,6 +108,7 @@ export const useOpenOrderLines = (): LineData[] => {
                     oid,
                     lineStyle: 3,
                     lineWidth: 1,
+                    side: side,
                 };
             });
 


### PR DESCRIPTION
While dragging to update an open limit order in a different theme, the new order is sent with the wrong side (e.g., buy instead of sell), causing the order to be executed immediately