### PR TITLE
Cache onchain page log to reduce transaction send latency

### DIFF
--- a/packages/frontend/app/hooks/useMarketOrderLog.ts
+++ b/packages/frontend/app/hooks/useMarketOrderLog.ts
@@ -1,0 +1,63 @@
+import { isEstablished, useSession } from '@fogo/sessions-sdk-react';
+import { useCallback, useEffect, useRef } from 'react';
+import { marketOrderLogManager } from '~/services/MarketOrderLogManager';
+
+/**
+ * Hook to manage market order log page pre-fetching
+ * This hook subscribes to the market order log manager when the session is established
+ * and ensures the log page is cached for faster transaction building
+ */
+export function useMarketOrderLog() {
+    const sessionState = useSession();
+    const hasSubscribedRef = useRef(false);
+    const lastSessionStateRef = useRef<boolean>(false);
+
+    const isSessionEstablished = isEstablished(sessionState);
+
+    useEffect(() => {
+        // Track session state changes
+        const sessionChanged =
+            lastSessionStateRef.current !== isSessionEstablished;
+        lastSessionStateRef.current = isSessionEstablished;
+
+        if (!isSessionEstablished) {
+            // Only unsubscribe if we were actually subscribed
+            if (hasSubscribedRef.current) {
+                hasSubscribedRef.current = false;
+                marketOrderLogManager.unsubscribe();
+            }
+            return;
+        }
+
+        // Subscribe only if not already subscribed and session just became established
+        if (!hasSubscribedRef.current && sessionChanged) {
+            hasSubscribedRef.current = true;
+            marketOrderLogManager.subscribe(sessionState.connection);
+        }
+
+        // Cleanup function - runs on unmount and when dependencies change
+        return () => {
+            if (hasSubscribedRef.current) {
+                hasSubscribedRef.current = false;
+                marketOrderLogManager.unsubscribe();
+            }
+        };
+    }, [isSessionEstablished]); // Only depend on session established state
+
+    const forceRefresh = useCallback(async () => {
+        if (!isSessionEstablished) {
+            throw new Error('Cannot refresh: session not established');
+        }
+
+        return marketOrderLogManager.forceRefresh();
+    }, [isSessionEstablished]);
+
+    const getCachedLogPage = useCallback(() => {
+        return marketOrderLogManager.getCachedLogPage();
+    }, []);
+
+    return {
+        forceRefresh,
+        getCachedLogPage,
+    };
+}

--- a/packages/frontend/app/routes/trade/webdataconsumer.tsx
+++ b/packages/frontend/app/routes/trade/webdataconsumer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import type { TransactionData } from '~/components/Trade/DepositsWithdrawalsTable/DepositsWithdrawalsTableRow';
 import useNumFormatter from '~/hooks/useNumFormatter';
 import { useSdk } from '~/hooks/useSdk';
+import { useMarketOrderLog } from '~/hooks/useMarketOrderLog';
 import { useUnifiedMarginData } from '~/hooks/useUnifiedMarginData';
 import { useWorker } from '~/hooks/useWorker';
 import type { WebData2Output } from '~/hooks/workers/webdata2.worker';
@@ -72,6 +73,9 @@ export default function WebDataConsumer() {
 
     // Use unified margin data for both balance and positions
     const { positions: unifiedPositions } = useUnifiedMarginData();
+
+    // Initialize market order log pre-fetching
+    useMarketOrderLog();
 
     const openOrdersRef = useRef<OrderDataIF[]>([]);
     const positionsRef = useRef<PositionIF[]>([]);

--- a/packages/frontend/app/services/MarketOrderLogManager.ts
+++ b/packages/frontend/app/services/MarketOrderLogManager.ts
@@ -1,0 +1,144 @@
+import {
+    DFLT_EMBER_MARKET,
+    getCurrentLogPage,
+    getMarketOrderLogInfo,
+} from '@crocswap-libs/ambient-ember';
+import type { Connection } from '@solana/web3.js';
+
+/**
+ * Singleton manager for pre-fetching and caching market order log page
+ * This reduces latency when building order transactions
+ */
+class MarketOrderLogManager {
+    private static instance: MarketOrderLogManager | null = null;
+    private intervalId: NodeJS.Timeout | null = null;
+    private isPolling = false;
+    private connection: Connection | null = null;
+    private cachedLogPage: number | undefined = undefined;
+    private lastFetchTime = 0;
+    private pollingInterval = 30000; // Poll every 30 seconds
+    private subscriberCount = 0;
+
+    private constructor() {}
+
+    static getInstance(): MarketOrderLogManager {
+        if (!MarketOrderLogManager.instance) {
+            MarketOrderLogManager.instance = new MarketOrderLogManager();
+        }
+        return MarketOrderLogManager.instance;
+    }
+
+    /**
+     * Subscribe to market order log updates
+     * @param connection Solana connection
+     */
+    subscribe(connection: Connection): void {
+        this.subscriberCount++;
+
+        // Update connection if changed
+        if (this.connection !== connection) {
+            this.stop();
+            this.connection = connection;
+        }
+
+        // Start polling if not already active
+        if (!this.isPolling && this.connection) {
+            this.start();
+        }
+    }
+
+    /**
+     * Unsubscribe from market order log updates
+     */
+    unsubscribe(): void {
+        this.subscriberCount--;
+
+        if (this.subscriberCount <= 0) {
+            this.subscriberCount = 0;
+            this.stop();
+        }
+    }
+
+    /**
+     * Get the cached market order log page
+     * @returns The cached log page number or undefined if not available
+     */
+    getCachedLogPage(): number | undefined {
+        return this.cachedLogPage;
+    }
+
+    /**
+     * Force an immediate refresh of the market order log page
+     */
+    async forceRefresh(): Promise<void> {
+        if (!this.connection) {
+            throw new Error('Cannot refresh: no connection');
+        }
+
+        this.lastFetchTime = 0;
+        return this.fetchData();
+    }
+
+    private start(): void {
+        if (this.isPolling || !this.connection) {
+            return;
+        }
+
+        this.isPolling = true;
+
+        // Clear any existing interval
+        if (this.intervalId) {
+            clearInterval(this.intervalId);
+            this.intervalId = null;
+        }
+
+        // Initial fetch
+        this.fetchData();
+
+        // Set up polling
+        this.intervalId = setInterval(() => {
+            this.fetchData();
+        }, this.pollingInterval);
+    }
+
+    private stop(): void {
+        if (this.intervalId) {
+            clearInterval(this.intervalId);
+            this.intervalId = null;
+        }
+
+        this.isPolling = false;
+        this.cachedLogPage = undefined;
+    }
+
+    private async fetchData(): Promise<void> {
+        if (!this.connection) {
+            return;
+        }
+
+        const now = Date.now();
+        this.lastFetchTime = now;
+
+        try {
+            // Get the market order log info
+            const marketId = BigInt(DFLT_EMBER_MARKET.mktId);
+            this.cachedLogPage = await getCurrentLogPage(
+                this.connection,
+                marketId,
+            );
+
+            console.log(
+                '[MarketOrderLogManager] Updated cached log page:',
+                this.cachedLogPage,
+            );
+        } catch (error) {
+            console.error(
+                '[MarketOrderLogManager] Error fetching market order log:',
+                error,
+            );
+            // Don't clear the cache on error - keep using the last known value
+        }
+    }
+}
+
+export const marketOrderLogManager = MarketOrderLogManager.getInstance();

--- a/packages/frontend/app/services/cancelOrderService.ts
+++ b/packages/frontend/app/services/cancelOrderService.ts
@@ -3,6 +3,7 @@ import {
     buildCancelOrderTransaction,
 } from '@crocswap-libs/ambient-ember';
 import { Connection, PublicKey } from '@solana/web3.js';
+import { marketOrderLogManager } from './MarketOrderLogManager';
 
 export interface CancelOrderResult {
     success: boolean;
@@ -56,6 +57,15 @@ export class CancelOrderService {
                     ? params.orderId
                     : BigInt(params.orderId);
 
+            // Get the cached market order log page to avoid RPC call
+            const cachedLogPage = marketOrderLogManager.getCachedLogPage();
+            if (cachedLogPage !== undefined) {
+                console.log(
+                    '  - Using cached marketOrderLogPage:',
+                    cachedLogPage,
+                );
+            }
+
             const transaction = await buildCancelOrderTransaction(
                 this.connection,
                 {
@@ -64,6 +74,7 @@ export class CancelOrderService {
                     user: userPublicKey,
                     actor: sessionPublicKey,
                     rentPayer: rentPayer,
+                    marketOrderLogPage: cachedLogPage,
                 },
             );
 

--- a/packages/frontend/app/services/limitOrderService.ts
+++ b/packages/frontend/app/services/limitOrderService.ts
@@ -5,6 +5,7 @@ import {
     buildOrderEntryTransaction,
 } from '@crocswap-libs/ambient-ember';
 import { Connection, PublicKey } from '@solana/web3.js';
+import { marketOrderLogManager } from './MarketOrderLogManager';
 
 export interface LimitOrderResult {
     success: boolean;
@@ -87,6 +88,15 @@ export class LimitOrderService {
                 );
             }
 
+            // Get the cached market order log page to avoid RPC call
+            const cachedLogPage = marketOrderLogManager.getCachedLogPage();
+            if (cachedLogPage !== undefined) {
+                console.log(
+                    '  - Using cached marketOrderLogPage:',
+                    cachedLogPage,
+                );
+            }
+
             // Build the appropriate transaction based on side
             if (params.side === 'buy') {
                 console.log('  - Building limit BUY order...');
@@ -103,6 +113,7 @@ export class LimitOrderService {
                     userSetImBps: userSetImBps,
                     includesFillAtMarket: true,
                     cancelOrderId: params.replaceOrderId,
+                    marketOrderLogPage: cachedLogPage,
                 };
 
                 const transaction = buildOrderEntryTransaction(
@@ -127,6 +138,7 @@ export class LimitOrderService {
                     userSetImBps: userSetImBps,
                     includesFillAtMarket: true,
                     cancelOrderId: params.replaceOrderId,
+                    marketOrderLogPage: cachedLogPage,
                 };
 
                 console.log('  - Order parameters:', orderParams);

--- a/packages/frontend/app/services/marketOrderService.ts
+++ b/packages/frontend/app/services/marketOrderService.ts
@@ -6,6 +6,7 @@ import {
 } from '@crocswap-libs/ambient-ember';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { MARKET_ORDER_PRICE_OFFSET_USD } from '~/utils/Constants';
+import { marketOrderLogManager } from './MarketOrderLogManager';
 
 export interface MarketOrderResult {
     success: boolean;
@@ -75,6 +76,15 @@ export class MarketOrderService {
                 console.log('  - Calculated userSetImBps:', userSetImBps);
             }
 
+            // Get the cached market order log page to avoid RPC call
+            const cachedLogPage = marketOrderLogManager.getCachedLogPage();
+            if (cachedLogPage !== undefined) {
+                console.log(
+                    '  - Using cached marketOrderLogPage:',
+                    cachedLogPage,
+                );
+            }
+
             // Calculate fill prices based on order book
             let fillPrice: bigint;
             if (params.side === 'buy') {
@@ -118,6 +128,8 @@ export class MarketOrderService {
             // Build the appropriate transaction based on side
             if (params.side === 'buy') {
                 console.log('  - Building market BUY order...');
+                console.log('  - Log page:', cachedLogPage);
+
                 const orderParams: any = {
                     marketId: marketId,
                     orderId: orderId,
@@ -132,6 +144,7 @@ export class MarketOrderService {
                     keeper: sessionPublicKey,
                     userSetImBps: userSetImBps,
                     includesFillAtMarket: true,
+                    marketOrderLogPage: cachedLogPage,
                 };
 
                 const transaction = buildOrderEntryTransaction(
@@ -158,6 +171,7 @@ export class MarketOrderService {
                     keeper: sessionPublicKey,
                     userSetImBps: userSetImBps,
                     includesFillAtMarket: true, // Ensure fill at market is included
+                    marketOrderLogPage: cachedLogPage,
                 };
 
                 const transaction = buildOrderEntryTransaction(


### PR DESCRIPTION
Creates a new hook that uses a 30 second poll to pre-fetch a cached value for `marketOrderLogPage` param. Previously this param was not passed to SDK build transaction functions, which introduced a round trip RPC query in the hot path. By caching the value ahead of time latency in the hot path should be reduced.