### PR TITLE
fixed : overlay canvas disappear when volume pane move to top

### DIFF
--- a/packages/frontend/app/routes/chart/orders/OrderLines.tsx
+++ b/packages/frontend/app/routes/chart/orders/OrderLines.tsx
@@ -5,7 +5,10 @@ import LineComponent, { type LineData } from './component/LineComponent';
 import LabelComponent from './component/LabelComponent';
 import { useTradingView } from '~/contexts/TradingviewContext';
 import type { IPaneApi } from '~/tv/charting_library';
-import type { LabelLocationData } from '../overlayCanvas/overlayCanvasUtils';
+import {
+    getMainSeriesPaneIndex,
+    type LabelLocationData,
+} from '../overlayCanvas/overlayCanvasUtils';
 import { getPricetoPixel } from './customOrderLineUtils';
 import { MIN_VISIBLE_ORDER_LABEL_RATIO } from '~/utils/Constants';
 
@@ -69,7 +72,9 @@ export default function OrderLines({
         if (!chart || !scaleData) return;
 
         const chartRef = chart.activeChart();
-        const priceScalePane = chartRef.getPanes()[0] as IPaneApi;
+        const paneIndex = getMainSeriesPaneIndex(chart);
+        if (paneIndex === null) return;
+        const priceScalePane = chartRef.getPanes()[paneIndex] as IPaneApi;
         const priceScale = priceScalePane.getMainSourcePriceScale();
         if (!priceScale) return;
 

--- a/packages/frontend/app/routes/chart/orders/component/LabelComponent.ts
+++ b/packages/frontend/app/routes/chart/orders/component/LabelComponent.ts
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useTradingView } from '~/contexts/TradingviewContext';
 import { useCancelOrderService } from '~/hooks/useCancelOrderService';
 import { useLimitOrderService } from '~/hooks/useLimitOrderService';
@@ -11,6 +11,8 @@ import type { IPaneApi } from '~/tv/charting_library';
 import { blockExplorer } from '~/utils/Constants';
 import {
     findLimitLabelAtPosition,
+    getMainSeriesPaneIndex,
+    getPaneCanvasAndIFrameDoc,
     getXandYLocationForChartDrag,
     type LabelLocationData,
 } from '../../overlayCanvas/overlayCanvasUtils';
@@ -77,32 +79,25 @@ const LabelComponent = ({
             let widthAttr = canvasSize?.width;
 
             if (overlayCanvasRef.current) {
-                const chartDiv = document.getElementById('tv_chart');
-                const iframe = chartDiv?.querySelector(
-                    'iframe',
-                ) as HTMLIFrameElement;
-                const iframeDoc =
-                    iframe?.contentDocument || iframe?.contentWindow?.document;
+                const { iframeDoc, paneCanvas } =
+                    getPaneCanvasAndIFrameDoc(chart);
 
-                if (iframeDoc) {
-                    const paneCanvas = iframeDoc.querySelector(
-                        'canvas[data-name="pane-canvas"]',
-                    ) as HTMLCanvasElement;
-                    const width = overlayCanvasRef.current.style.width;
-                    const height = overlayCanvasRef.current.style?.height;
+                if (!iframeDoc || !paneCanvas || !paneCanvas.parentNode) return;
 
-                    heightAttr = paneCanvas?.height;
-                    widthAttr = paneCanvas.width;
+                const width = overlayCanvasRef.current.style.width;
+                const height = overlayCanvasRef.current.style?.height;
 
-                    if (
-                        width !== canvasSize?.styleWidth ||
-                        height !== canvasSize?.styleWidth
-                    ) {
-                        overlayCanvasRef.current.style.width = `${canvasSize?.styleWidth}px`;
-                        overlayCanvasRef.current.style.height = `${canvasSize?.styleHeight}px`;
-                        overlayCanvasRef.current.width = paneCanvas.width;
-                        overlayCanvasRef.current.height = paneCanvas.height;
-                    }
+                heightAttr = paneCanvas?.height;
+                widthAttr = paneCanvas.width;
+
+                if (
+                    width !== canvasSize?.styleWidth ||
+                    height !== canvasSize?.styleWidth
+                ) {
+                    overlayCanvasRef.current.style.width = `${canvasSize?.styleWidth}px`;
+                    overlayCanvasRef.current.style.height = `${canvasSize?.styleHeight}px`;
+                    overlayCanvasRef.current.width = paneCanvas.width;
+                    overlayCanvasRef.current.height = paneCanvas.height;
                 }
             }
 
@@ -214,7 +209,7 @@ const LabelComponent = ({
         selectedLine,
     ]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (!isDrag) {
             const overlayOffsetX = overlayCanvasMousePositionRef.current.x;
             const overlayOffsetY = overlayCanvasMousePositionRef.current.y;
@@ -235,7 +230,8 @@ const LabelComponent = ({
             }
         }
     }, [
-        overlayCanvasMousePositionRef.current,
+        overlayCanvasMousePositionRef.current.x,
+        overlayCanvasMousePositionRef.current.y,
         JSON.stringify(drawnLabelsRef.current),
         isDrag,
     ]);
@@ -248,51 +244,39 @@ const LabelComponent = ({
                     .crossHairMoved()
                     .subscribe(null, ({ offsetX, offsetY }) => {
                         if (chart) {
-                            const chartDiv =
-                                document.getElementById('tv_chart');
-                            const iframe = chartDiv?.querySelector(
-                                'iframe',
-                            ) as HTMLIFrameElement;
+                            const { paneCanvas } =
+                                getPaneCanvasAndIFrameDoc(chart);
 
-                            const iframeDoc = iframe.contentDocument;
+                            if (!paneCanvas) return;
 
-                            if (iframeDoc) {
-                                const paneCanvas = iframeDoc.querySelector(
-                                    'canvas[data-name="pane-canvas"]',
-                                ) as HTMLCanvasElement;
+                            const rect = paneCanvas?.getBoundingClientRect();
 
-                                const rect =
-                                    paneCanvas?.getBoundingClientRect();
+                            if (rect && paneCanvas && offsetX && offsetY) {
+                                const cssOffsetX = offsetX - rect.left;
+                                const cssOffsetY = offsetY - rect.top;
 
-                                if (rect && paneCanvas && offsetX && offsetY) {
-                                    const cssOffsetX = offsetX - rect.left;
-                                    const cssOffsetY = offsetY - rect.top;
+                                const scaleY =
+                                    paneCanvas?.height / rect?.height;
+                                const scaleX = paneCanvas.width / rect.width;
 
-                                    const scaleY =
-                                        paneCanvas?.height / rect?.height;
-                                    const scaleX =
-                                        paneCanvas.width / rect.width;
+                                const overlayOffsetX = cssOffsetX * scaleX;
+                                const overlayOffsetY = cssOffsetY * scaleY;
 
-                                    const overlayOffsetX = cssOffsetX * scaleX;
-                                    const overlayOffsetY = cssOffsetY * scaleY;
+                                const isLabel = findLimitLabelAtPosition(
+                                    overlayOffsetX,
+                                    overlayOffsetY,
+                                    drawnLabelsRef.current,
+                                    false,
+                                );
+                                overlayCanvasMousePositionRef.current = {
+                                    x: overlayOffsetX,
+                                    y: overlayOffsetY,
+                                };
 
-                                    const isLabel = findLimitLabelAtPosition(
-                                        overlayOffsetX,
-                                        overlayOffsetY,
-                                        drawnLabelsRef.current,
-                                        false,
-                                    );
-
-                                    overlayCanvasMousePositionRef.current = {
-                                        x: overlayOffsetX,
-                                        y: overlayOffsetY,
-                                    };
-
-                                    if (isLabel) {
-                                        if (overlayCanvasRef.current)
-                                            overlayCanvasRef.current.style.pointerEvents =
-                                                'auto';
-                                    }
+                                if (isLabel) {
+                                    if (overlayCanvasRef.current)
+                                        overlayCanvasRef.current.style.pointerEvents =
+                                            'auto';
                                 }
                             }
                         }
@@ -472,9 +456,11 @@ const LabelComponent = ({
             let advancedValue = scaleData?.yScale.invert(clientY);
 
             if (chart) {
-                const priceScalePane = chart
-                    .activeChart()
-                    .getPanes()[0] as IPaneApi;
+                const paneIndex = getMainSeriesPaneIndex(chart);
+                if (paneIndex === null) return;
+                const priceScalePane = chart.activeChart().getPanes()[
+                    paneIndex
+                ] as IPaneApi;
 
                 const priceScale = priceScalePane.getMainSourcePriceScale();
                 if (priceScale) {

--- a/packages/frontend/app/routes/chart/orders/customOrderLineUtils.ts
+++ b/packages/frontend/app/routes/chart/orders/customOrderLineUtils.ts
@@ -1,4 +1,5 @@
 import type { IChartingLibraryWidget, IPaneApi } from '~/tv/charting_library';
+import { getMainSeriesPaneIndex } from '../overlayCanvas/overlayCanvasUtils';
 
 export type LineLabelType =
     | 'PNL'
@@ -87,8 +88,12 @@ export const getPricetoPixel = (
     const dpr = window.devicePixelRatio || 1;
     const textHeight = (lineType === 'LIQ' ? 18 : 15) * dpr;
     let pixel = 0;
-    const priceScalePane = chart.activeChart().getPanes()[0] as IPaneApi;
 
+    const paneIndex = getMainSeriesPaneIndex(chart);
+    if (paneIndex === null) return { pixel: 0, chartHeight: 0, textHeight: 0 };
+    const priceScalePane = chart.activeChart().getPanes()[
+        paneIndex
+    ] as IPaneApi;
     const priceScale = priceScalePane.getMainSourcePriceScale();
     if (priceScale) {
         const priceRange = priceScale.getVisiblePriceRange();

--- a/packages/frontend/app/routes/chart/overlayCanvas/overlayCanvas.tsx
+++ b/packages/frontend/app/routes/chart/overlayCanvas/overlayCanvas.tsx
@@ -1,117 +1,18 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useTradingView } from '~/contexts/TradingviewContext';
 import OrderLines from '../orders/OrderLines';
-import * as d3 from 'd3';
+import OverlayCanvasLayer from './overlayCanvasLayer';
 
 const OverlayCanvas: React.FC = () => {
-    const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const { chart } = useTradingView();
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [canvasSize, setCanvasSize] = useState<any>();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [scaleData, setScaleData] = useState<any>();
-
-    const overlayCanvasMousePositionRef = useRef({ x: 0, y: 0 });
-
-    useEffect(() => {
-        if (!chart) return;
-
-        const yScale = d3.scaleLinear();
-        const scaleSymlog = d3.scaleSymlog();
-        setScaleData(() => {
-            return { yScale: yScale, scaleSymlog: scaleSymlog };
-        });
-        const chartDiv = document.getElementById('tv_chart');
-        const iframe = chartDiv?.querySelector('iframe') as HTMLIFrameElement;
-        const iframeDoc =
-            iframe?.contentDocument || iframe?.contentWindow?.document;
-
-        if (!iframeDoc) return;
-
-        const paneCanvas = iframeDoc.querySelector(
-            'canvas[data-name="pane-canvas"]',
-        ) as HTMLCanvasElement;
-
-        if (!paneCanvas || !paneCanvas.parentNode) return;
-
-        if (!canvasRef.current) {
-            const newCanvas = iframeDoc.createElement('canvas');
-            newCanvas.id = 'overlay-canvas';
-            newCanvas.style.position = 'absolute';
-            newCanvas.style.top = '0';
-            newCanvas.style.left = '0';
-            newCanvas.style.cursor = 'pointer';
-            newCanvas.style.pointerEvents = 'none';
-            newCanvas.style.zIndex = '5';
-            newCanvas.width = paneCanvas.width;
-            newCanvas.height = paneCanvas?.height;
-            paneCanvas.parentNode.appendChild(newCanvas);
-
-            canvasRef.current = newCanvas;
-        }
-
-        const canvas = canvasRef.current;
-
-        const handleMouseMove = (e: MouseEvent) => {
-            const rect = canvas.getBoundingClientRect();
-            const offsetX = e.clientX - rect.left;
-            const offsetY = e.clientY - rect.top;
-
-            overlayCanvasMousePositionRef.current = { x: offsetX, y: offsetY };
-        };
-
-        canvas.addEventListener('mousemove', handleMouseMove);
-
-        const updateCanvasSize = () => {
-            const width = paneCanvas.width;
-            const height = paneCanvas?.height;
-
-            canvas.width = width;
-            canvas.style.width = `${width}px`;
-
-            canvas.height = height;
-            canvas.style.height = `${height}px`;
-
-            yScale.range([canvas.height, 0]);
-            scaleSymlog.range([canvas.height, 0]);
-        };
-
-        updateCanvasSize();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const observer = new ResizeObserver((result: any) => {
-            if (result) {
-                setCanvasSize({
-                    styleWidth: result[0].contentRect.width,
-                    styleHeight: result[0].contentRect?.height,
-                    width: paneCanvas.width,
-                    height: paneCanvas?.height,
-                });
-
-                yScale.range([result[0].contentRect?.height, 0]);
-                scaleSymlog.range([result[0].contentRect?.height, 0]);
-            }
-        });
-
-        observer.observe(paneCanvas);
-
-        return () => {
-            observer.disconnect();
-            if (canvas && canvas.parentNode) {
-                canvas.removeEventListener('mousemove', handleMouseMove);
-                canvas.parentNode.removeChild(canvas);
-            }
-            canvasRef.current = null;
-        };
-    }, [chart]);
-
     return (
-        <OrderLines
-            overlayCanvasRef={canvasRef}
-            canvasSize={canvasSize}
-            scaleData={scaleData}
-            overlayCanvasMousePositionRef={overlayCanvasMousePositionRef}
-        />
+        <OverlayCanvasLayer id='order-overlay' zIndex={5}>
+            {({ canvasRef, canvasSize, scaleData, mousePositionRef }) => (
+                <OrderLines
+                    overlayCanvasRef={canvasRef}
+                    canvasSize={canvasSize}
+                    scaleData={scaleData}
+                    overlayCanvasMousePositionRef={mousePositionRef}
+                />
+            )}
+        </OverlayCanvasLayer>
     );
 };
 

--- a/packages/frontend/app/routes/chart/overlayCanvas/overlayCanvasLayer.tsx
+++ b/packages/frontend/app/routes/chart/overlayCanvas/overlayCanvasLayer.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTradingView } from '~/contexts/TradingviewContext';
+import * as d3 from 'd3';
+import {
+    getPaneCanvasAndIFrameDoc,
+    mousePositionRef,
+    scaleDataRef,
+} from './overlayCanvasUtils';
+
+interface OverlayCanvasLayerProps {
+    id: string;
+    zIndex?: number;
+    pointerEvents?: 'none' | 'auto';
+    children: (props: {
+        canvasRef: React.RefObject<HTMLCanvasElement | null>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        canvasSize: any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        scaleData: any;
+        mousePositionRef: React.MutableRefObject<{ x: number; y: number }>;
+    }) => React.ReactNode;
+}
+
+const OverlayCanvasLayer: React.FC<OverlayCanvasLayerProps> = ({
+    id,
+    zIndex = 0,
+    pointerEvents = 'none',
+    children,
+}) => {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const { chart, isChartReady } = useTradingView();
+
+    const [isPaneChanged, setIsPaneChanged] = useState(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [canvasSize, setCanvasSize] = useState<any>();
+
+    useEffect(() => {
+        if (!chart || !isChartReady) return;
+
+        const isFirstInit = !scaleDataRef.current;
+
+        if (isFirstInit) {
+            const yScale = d3.scaleLinear();
+
+            const scaleSymlog = d3.scaleSymlog();
+            scaleDataRef.current = { yScale, scaleSymlog };
+        }
+
+        const yScale = scaleDataRef.current!.yScale;
+        const scaleSymlog = scaleDataRef.current!.scaleSymlog;
+
+        const { iframeDoc, paneCanvas } = getPaneCanvasAndIFrameDoc(chart);
+
+        if (!iframeDoc || !paneCanvas || !paneCanvas.parentNode) return;
+
+        if (!canvasRef.current) {
+            const newCanvas = iframeDoc.createElement('canvas');
+            newCanvas.id = id;
+            newCanvas.style.position = 'absolute';
+            newCanvas.style.top = '0';
+            newCanvas.style.left = '0';
+            newCanvas.style.cursor = 'pointer';
+            newCanvas.style.pointerEvents = pointerEvents;
+            newCanvas.style.zIndex = zIndex.toString();
+            newCanvas.width = paneCanvas.width;
+            newCanvas.height = paneCanvas.height;
+            paneCanvas.parentNode.appendChild(newCanvas);
+            canvasRef.current = newCanvas;
+        }
+
+        const canvas = canvasRef.current;
+
+        const handleMouseMove = (e: MouseEvent) => {
+            const rect = canvas.getBoundingClientRect();
+            const offsetX = e.clientX - rect.left;
+            const offsetY = e.clientY - rect.top;
+            mousePositionRef.current = { x: offsetX, y: offsetY };
+        };
+
+        canvas.addEventListener('mousemove', handleMouseMove);
+
+        const updateCanvasSize = () => {
+            const width = paneCanvas.width;
+            const height = paneCanvas?.height;
+
+            canvas.width = width;
+            canvas.style.width = `${width}px`;
+
+            canvas.height = height;
+            canvas.style.height = `${height}px`;
+
+            yScale.range([canvas.height, 0]);
+            scaleSymlog.range([canvas.height, 0]);
+        };
+
+        updateCanvasSize();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const observer = new ResizeObserver((result: any) => {
+            if (result) {
+                setCanvasSize({
+                    styleWidth: result[0].contentRect.width,
+                    styleHeight: result[0].contentRect?.height,
+                    width: paneCanvas.width,
+                    height: paneCanvas?.height,
+                });
+
+                yScale.range([result[0].contentRect?.height, 0]);
+                scaleSymlog.range([result[0].contentRect?.height, 0]);
+            }
+        });
+
+        observer.observe(paneCanvas);
+
+        return () => {
+            observer.disconnect();
+            if (canvas && canvas.parentNode) {
+                canvas.removeEventListener('mousemove', handleMouseMove);
+                canvas.parentNode.removeChild(canvas);
+            }
+            canvasRef.current = null;
+        };
+    }, [chart, isChartReady, isPaneChanged]);
+
+    useEffect(() => {
+        if (chart) {
+            chart.subscribe('panes_order_changed', () => {
+                if (canvasRef.current) {
+                    const ctx = canvasRef.current.getContext('2d');
+                    if (ctx) {
+                        ctx.clearRect(
+                            0,
+                            0,
+                            canvasRef.current.width,
+                            canvasRef.current.height,
+                        );
+                    }
+                }
+                setIsPaneChanged((prev) => !prev);
+            });
+        }
+    }, [chart]);
+
+    return (
+        <>
+            {children({
+                canvasRef,
+                canvasSize: canvasSize,
+                scaleData: scaleDataRef.current,
+                mousePositionRef,
+            })}
+        </>
+    );
+};
+
+export default OverlayCanvasLayer;


### PR DESCRIPTION
Overlay canvas disappears when the order of the main canvas panes changes, for example when an indicator is moved to the top pane