### PR TITLE
OrderBook | Fix blank area (Large Mode & Tablet style)

### DIFF
--- a/packages/frontend/app/routes/trade.module.css
+++ b/packages/frontend/app/routes/trade.module.css
@@ -190,7 +190,8 @@ body {
 
 /* Tablet styles */
 @media only screen and (max-width: 1080px) and (min-width: 769px) {
-    .containerTop {
+    .containerTop,
+    .containerTop.orderBookLarge {
         grid-template-columns: 1fr;
     }
 


### PR DESCRIPTION
Fixing blank area which triggered for tablet sizes once OrderBook large mode has been activated