### PR TITLE
Release 0.1.23

### DIFF
--- a/packages/frontend/app/components/Trade/MarketCloseModal/MarketCloseModal.tsx
+++ b/packages/frontend/app/components/Trade/MarketCloseModal/MarketCloseModal.tsx
@@ -286,6 +286,7 @@ export default function MarketCloseModal({ close, position }: PropsIF) {
                         props: {
                             actionType: 'Market Close Order Fail',
                             orderType: 'Market',
+                            errorMessage: result.error || 'Transaction failed',
                             direction: closingSide === 'buy' ? 'Buy' : 'Sell',
                             txDuration: getDurationSegment(
                                 timeOfSubmission,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@perps-app/frontend",
-    "version": "0.1.22",
+    "version": "0.1.22-1",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
- add fallback on markPx from pyth for market closes when orderbook not available