### PR TITLE
rework handle outside click to fix accidental closing of the modal

### DIFF
--- a/packages/frontend/app/components/Modal/Modal.tsx
+++ b/packages/frontend/app/components/Modal/Modal.tsx
@@ -52,91 +52,56 @@ function Modal(props: ModalProps) {
 
     const OUTSIDE_MODAL_DOM_ID = 'outside_modal';
 
-    // Memoize the close handler to prevent unnecessary re-renders
+    // Memoize the close handler
     const handleClose = useCallback((): void => {
         if (actualPosition === 'bottomSheet') {
             setAnimation(styles.slideDown);
             setTimeout(() => {
-                if (close) {
-                    close();
-                }
+                if (close) close();
             }, 300);
         } else {
-            if (close) {
-                close();
-            }
+            if (close) close();
         }
     }, [actualPosition, close]);
 
-    // Memoize the outside click handler
-    const handleOutsideClick = useCallback(
-        (target: HTMLDivElement): void => {
-            // Don't close if keyboard is visible (to prevent accidental dismissal)
-            if (isKeyboardVisible) return;
-
-            if (target.id === OUTSIDE_MODAL_DOM_ID && close) {
-                handleClose();
-            }
-        },
-        [OUTSIDE_MODAL_DOM_ID, close, handleClose, isKeyboardVisible],
-    );
-
-    // return children without creating curtain behind modal
-    // this allows us to make multiple non-exclusive modals at once
+    // return children without curtain if no close handler
     if (!close) return children;
 
-    // Use requestAnimationFrame for smooth animations
+    // Use requestAnimationFrame for smooth drag updates
     const updateDragPosition = useCallback((deltaY: number) => {
         if (!bottomSheetRef.current) return;
-
         requestAnimationFrame(() => {
             if (bottomSheetRef.current) {
                 bottomSheetRef.current.style.transform = `translateY(${deltaY}px)`;
-                bottomSheetRef.current.style.transition = 'none'; // Disable transition during drag
+                bottomSheetRef.current.style.transition = 'none';
             }
         });
     }, []);
 
-    // Batch related state updates for starting drag
     const startDragging = useCallback((clientY: number) => {
-        dragState.current = {
-            startY: clientY,
-            currentY: 0,
-            isDragging: true,
-        };
-
+        dragState.current = { startY: clientY, currentY: 0, isDragging: true };
         if (handleRef.current) {
             handleRef.current.classList.add(styles.dragging);
         }
     }, []);
 
-    // Handle drag start - memoized
     const handleDragStart = useCallback(
         (e: React.TouchEvent | React.MouseEvent): void => {
-            // Don't allow dragging when keyboard is visible
-            // if (isKeyboardVisible || !bottomSheetRef.current) return;
             if (!bottomSheetRef.current) return;
-            // First dismiss the keyboard if it's visible
+
             if (
                 isKeyboardVisible &&
                 document.activeElement instanceof HTMLElement
             ) {
                 document.activeElement.blur();
-                // Small delay to allow keyboard to dismiss
-                setTimeout(() => {
-                    setIsKeyboardVisible(false);
-                }, 50);
+                setTimeout(() => setIsKeyboardVisible(false), 50);
             }
 
             let clientY: number;
-
             if ('touches' in e) {
-                // Touch event
                 clientY = e.touches[0].clientY;
             } else {
-                // Mouse event
                 clientY = (e as React.MouseEvent).clientY;
-                // For mouse events, we need to add event listeners to document
                 document.addEventListener(
                     'mousemove',
                     handleDragMove as unknown as EventListener,
@@ -152,43 +117,26 @@ function Modal(props: ModalProps) {
         [startDragging, isKeyboardVisible],
     );
 
-    // Handle drag move - memoized
     const handleDragMove = useCallback(
         (e: React.TouchEvent | MouseEvent): void => {
             if (!dragState.current.isDragging || !bottomSheetRef.current)
                 return;
-
             let clientY: number;
+            if ('touches' in e) clientY = e.touches[0].clientY;
+            else clientY = (e as MouseEvent).clientY;
 
-            if ('touches' in e) {
-                // Touch event
-                clientY = e.touches[0].clientY;
-            } else {
-                // Mouse event
-                clientY = (e as MouseEvent).clientY;
-            }
-
-            // Calculate how far we've dragged
             const deltaY = clientY - dragState.current.startY;
-
-            // Don't allow dragging up beyond the top
             if (deltaY < 0) return;
 
             dragState.current.currentY = deltaY;
-
-            // Apply the transformation using requestAnimationFrame
             updateDragPosition(deltaY);
         },
         [updateDragPosition],
     );
 
-    // Handle drag end - memoized
     const handleDragEnd = useCallback((): void => {
-        if (!dragState.current.isDragging || !bottomSheetRef.current) {
-            return;
-        }
+        if (!dragState.current.isDragging || !bottomSheetRef.current) return;
 
-        // Clean up event listeners for mouse events
         document.removeEventListener(
             'mousemove',
             handleDragMove as unknown as EventListener,
@@ -198,21 +146,15 @@ function Modal(props: ModalProps) {
             handleDragEnd as unknown as EventListener,
         );
 
-        // Re-enable transition
         bottomSheetRef.current.style.transition = 'transform 0.3s ease-out';
-
-        // If dragged more than 30% of the height, close the sheet
         const sheetHeight = bottomSheetRef.current.offsetHeight;
         if (dragState.current.currentY > sheetHeight * 0.3) {
             handleClose();
         } else {
-            // Otherwise snap back to open position
             bottomSheetRef.current.style.transform = 'translateY(0)';
         }
 
         dragState.current.isDragging = false;
-
-        // Remove active class
         if (handleRef.current) {
             handleRef.current.classList.remove(styles.dragging);
         }
@@ -221,19 +163,13 @@ function Modal(props: ModalProps) {
     // Keyboard detection effect
     useEffect(() => {
         const detectKeyboard = () => {
-            // Use visualViewport API if available (modern browsers)
             if (window.visualViewport) {
                 const handler = () => {
-                    // When keyboard opens, the viewport height becomes smaller than window inner height
                     const keyboardVisible =
                         window.visualViewport!.height < window.innerHeight;
-
                     if (keyboardVisible !== isKeyboardVisible) {
                         setIsKeyboardVisible(keyboardVisible);
-
-                        // Scroll to active element when keyboard opens
                         if (keyboardVisible && document.activeElement) {
-                            // Add a small delay to ensure the keyboard is fully visible
                             setTimeout(() => {
                                 (
                                     document.activeElement as HTMLElement
@@ -245,7 +181,6 @@ function Modal(props: ModalProps) {
                         }
                     }
                 };
-
                 window.visualViewport.addEventListener('resize', handler);
                 return () =>
                     window.visualViewport!.removeEventListener(
@@ -253,69 +188,33 @@ function Modal(props: ModalProps) {
                         handler,
                     );
             }
-
-            // Fallback for older browsers using focus/blur events on input fields
-            const handleFocus = () => setIsKeyboardVisible(true);
-            const handleBlur = () => {
-                // Small delay to prevent flickering
-                setTimeout(() => setIsKeyboardVisible(false), 100);
-            };
-
-            const addInputListeners = (element: HTMLElement) => {
-                const inputs = element.querySelectorAll('input, textarea');
-                inputs.forEach((input) => {
-                    input.addEventListener('focus', handleFocus);
-                    input.addEventListener('blur', handleBlur);
-                });
-
-                return () => {
-                    inputs.forEach((input) => {
-                        input.removeEventListener('focus', handleFocus);
-                        input.removeEventListener('blur', handleBlur);
-                    });
-                };
-            };
-
-            // Only add listeners if the content ref is available
-            if (contentRef.current) {
-                return addInputListeners(contentRef.current);
-            }
-
             return undefined;
         };
-
         return detectKeyboard();
     }, [isKeyboardVisible]);
 
-    // Prevent background content from scrolling when modal is open
+    // Prevent background scroll
     useEffect(() => {
         document.body.style.overflow = 'hidden';
-
-        // Prevent iOS safari from allowing swipe-up gestures on the modal
         const preventDefaultTouchMove = (e: TouchEvent) => {
             if (modalRef.current?.contains(e.target as Node)) {
                 e.preventDefault();
             }
         };
-
         document.addEventListener('touchmove', preventDefaultTouchMove, {
             passive: false,
         });
-
         return () => {
             document.body.style.overflow = '';
             document.removeEventListener('touchmove', preventDefaultTouchMove);
         };
     }, []);
 
-    // event listener to close modal on `Escape` keydown event
+    // Escape key close
     useEffect(() => {
         let animationTimeout: number;
-        const EVENT_TYPE = 'keydown';
-
-        function handleEscape(evt: KeyboardEvent): void {
+        const handleEscape = (evt: KeyboardEvent): void => {
             if (evt.key === 'Escape' && close) {
-                // If keyboard is visible, just blur the active element
                 if (
                     isKeyboardVisible &&
                     document.activeElement instanceof HTMLElement
@@ -325,40 +224,33 @@ function Modal(props: ModalProps) {
                 }
                 handleClose();
             }
-        }
-
-        // Add animation class on mount for bottom sheet
+        };
         if (actualPosition === 'bottomSheet') {
-            // Slight delay to ensure the initial transform is applied first
-            animationTimeout = window.setTimeout(() => {
-                setAnimation(styles.slideUp);
-            }, 10);
+            animationTimeout = window.setTimeout(
+                () => setAnimation(styles.slideUp),
+                10,
+            );
         }
-
-        // add the event listener to the DOM
-        document.addEventListener(EVENT_TYPE, handleEscape);
-
-        // remove event listener from the DOM when component unmounts
+        document.addEventListener('keydown', handleEscape);
         return () => {
-            document.removeEventListener(EVENT_TYPE, handleEscape);
+            document.removeEventListener('keydown', handleEscape);
             if (animationTimeout) window.clearTimeout(animationTimeout);
         };
     }, [actualPosition, close, handleClose, isKeyboardVisible]);
 
-    // Blur any active element when tapping the modal background
-    const handleBackdropClick = useCallback(
-        (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-            if (
-                e.target === e.currentTarget &&
-                document.activeElement instanceof HTMLElement
-            ) {
-                document.activeElement.blur();
-            }
-        },
-        [],
-    );
+    const pointerDownOnBackdrop = useRef(false);
+    const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
+    const MOVE_TOLERANCE = 6;
+    function distance(
+        a: { x: number; y: number },
+        b: { x: number; y: number },
+    ) {
+        const dx = a.x - b.x,
+            dy = a.y - b.y;
+        return Math.hypot(dx, dy);
+    }
+    // -------------------------------------------
 
-    // Memoize the modal header
     const modalHeader = useMemo(
         () => (
             <header>
@@ -374,7 +266,6 @@ function Modal(props: ModalProps) {
         [title, shouldUseBottomSheet, handleClose],
     );
 
-    // Memoize the modal content
     const modalContent = useMemo(
         () => (
             <div ref={contentRef} className={styles.modalContent}>
@@ -388,10 +279,6 @@ function Modal(props: ModalProps) {
     return (
         <div
             ref={modalRef}
-            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-                handleOutsideClick(e.target as HTMLDivElement);
-                handleBackdropClick(e);
-            }}
             id={OUTSIDE_MODAL_DOM_ID}
             className={`${styles.outside_modal} ${
                 actualPosition === 'bottomSheet'
@@ -403,11 +290,50 @@ function Modal(props: ModalProps) {
             role='dialog'
             aria-modal='true'
             aria-labelledby='modal-title'
+            // NEW pointer-aware outside close
+            onMouseDown={(e) => {
+                pointerDownOnBackdrop.current = e.target === e.currentTarget;
+                pointerDownPos.current = { x: e.clientX, y: e.clientY };
+            }}
+            onTouchStart={(e) => {
+                const t = e.touches[0];
+                pointerDownOnBackdrop.current = e.target === e.currentTarget;
+                pointerDownPos.current = { x: t.clientX, y: t.clientY };
+            }}
+            onMouseUp={(e) => {
+                if (!pointerDownOnBackdrop.current) return;
+                if (e.target !== e.currentTarget) return;
+                if (
+                    pointerDownPos.current &&
+                    distance(pointerDownPos.current, {
+                        x: e.clientX,
+                        y: e.clientY,
+                    }) > MOVE_TOLERANCE
+                )
+                    return;
+                handleClose();
+            }}
+            onTouchEnd={(e) => {
+                if (!pointerDownOnBackdrop.current) return;
+                const t = e.changedTouches[0];
+                if (!t) return;
+                if (
+                    pointerDownPos.current &&
+                    distance(pointerDownPos.current, {
+                        x: t.clientX,
+                        y: t.clientY,
+                    }) > MOVE_TOLERANCE
+                )
+                    return;
+                handleClose();
+            }}
         >
             {actualPosition === 'bottomSheet' ? (
                 <div
                     ref={bottomSheetRef}
-                    className={`${styles.bottomSheet} ${animation} ${isKeyboardVisible ? styles.keyboardActive : ''}`}
+                    className={`${styles.bottomSheet} ${animation} ${
+                        isKeyboardVisible ? styles.keyboardActive : ''
+                    }`}
                 >
                     <div
                         ref={handleRef}
@@ -419,12 +345,10 @@ function Modal(props: ModalProps) {
                     >
                         <div className={styles.handle}></div>
                     </div>
-
                     {modalHeader}
                     {modalContent}
                 </div>
             ) : (
-                // Center or other position modals - use centered styling
                 <div className={styles.centerModal}>
                     {modalHeader}
                     {modalContent}


### PR DESCRIPTION
Prevent modals from closing when releasing a drag outside the modal.
Previously, any mouse/touch release outside the modal was treated as a backdrop click, which caused accidental dismissals, especially with the slider. Now the modal only closes if the interaction starts and ends on the backdrop.