### PR TITLE
OrderBook | Hide scrollbars for Stacked and Large Mode

### DIFF
--- a/packages/frontend/app/routes/trade/orderbook/orderbooksection.module.css
+++ b/packages/frontend/app/routes/trade/orderbook/orderbooksection.module.css
@@ -6,6 +6,7 @@
     width: 100%;
     height: 100%;
     font-size: var(--font-size-s);
+    scrollbar-width: none;
 }
 
 .orderBookSectionContainer {


### PR DESCRIPTION
Hiding scrollbars for stacked and large mode once layout height has been changed