### PR TITLE
Filled size column sorting breaks after switching page language to Turkish bug has solved

### DIFF
--- a/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
+++ b/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTable.module.css
@@ -48,6 +48,25 @@
     align-items: center;
     gap: var(--gap-xs);
     cursor: default;
+    min-width: 0;
+    box-sizing: border-box;
+}
+
+.headerLabel {
+    flex: 1 1 0;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+}
+
+.sortIconWrapper {
+    flex: 0 0 auto;
+    margin-left: 8px;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
 }
 
 .sortable {

--- a/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTableHeader.tsx
+++ b/packages/frontend/app/components/Trade/OrderHistoryTable/OrderHistoryTableHeader.tsx
@@ -154,20 +154,28 @@ export const OrderHistoryTableHeader = ({
                     key={header.key}
                     className={`${styles.cell} ${styles.headerCell} ${styles[header.className]} ${header.sortable ? styles.sortable : ''} ${header.key === sortBy ? styles.active : ''}`}
                     onClick={() => {
-                        if (header.sortable) {
-                            sortClickHandler(header.key as OrderDataSortBy);
-                        }
+                        if (!header.sortable) return;
+
+                        sortClickHandler(String(header.key) as OrderDataSortBy);
                     }}
+                    title={
+                        typeof header.name === 'string'
+                            ? header.name
+                            : undefined
+                    }
                 >
-                    {header.name}
+                    <span className={styles.headerLabel}>{header.name}</span>
+
                     {header.sortable && (
-                        <SortIcon
-                            sortDirection={
-                                sortDirection && header.key === sortBy
-                                    ? sortDirection
-                                    : undefined
-                            }
-                        />
+                        <span className={styles.sortIconWrapper}>
+                            <SortIcon
+                                sortDirection={
+                                    sortDirection && header.key === sortBy
+                                        ? sortDirection
+                                        : undefined
+                                }
+                            />
+                        </span>
                     )}
                 </div>
             ))}

--- a/packages/frontend/app/utils/orderbook/OrderBookIFs.ts
+++ b/packages/frontend/app/utils/orderbook/OrderBookIFs.ts
@@ -78,4 +78,5 @@ export type OrderDataSortBy =
     | 'cancel'
     | 'limitPx'
     | 'triggerPx'
+    | 'filledSz'
     | undefined;

--- a/packages/frontend/app/utils/orderbook/OrderBookUtils.ts
+++ b/packages/frontend/app/utils/orderbook/OrderBookUtils.ts
@@ -200,6 +200,12 @@ export const sortOrderData = (
                 return [...orderData].sort((a, b) =>
                     sortDirection === 'asc' ? a.sz - b.sz : b.sz - a.sz,
                 );
+            case 'filledSz':
+                return [...orderData].sort((a, b) => {
+                    const va = a.filledSz ?? -Infinity;
+                    const vb = b.filledSz ?? -Infinity;
+                    return sortDirection === 'asc' ? va - vb : vb - va;
+                });
             case 'origSz':
                 return [...orderData].sort((a, b) =>
                     sortDirection === 'asc'


### PR DESCRIPTION
Updated OrderHistoryTable.module.css, OrderHistoryTableHeader.tsx, OrderBookIF.ts, OrderBookUtils.ts to fix column sorting breaks after switching page language to Turkish bug has solved
<img width="1898" height="902" alt="image-2025-10-06-15-43-17-199" src="https://github.com/user-attachments/assets/1fc813d1-0f45-4df1-be40-3f4083922b17" />
