### PR TITLE
Fix links crash

### DIFF
--- a/packages/frontend/app/routes/affiliates/views/LinksView.tsx
+++ b/packages/frontend/app/routes/affiliates/views/LinksView.tsx
@@ -25,7 +25,6 @@ import { CreateReferralCodeModal } from '../components/CreateReferralCode/Create
 import styles from '../affiliates.module.css';
 
 export function LinksView() {
-    console.log('running');
     const allowMultipleAffiliateCodes = false;
     const sessionState = useSession();
     const isConnected = isEstablished(sessionState);
@@ -141,7 +140,6 @@ export function LinksView() {
     const canCreateCode = allowMultipleAffiliateCodes || !hasCreatedCode;
     const createCodeDisabledMessage =
         'Creating multiple referral codes is currently disabled. You can only have one code per wallet.';
-    console.log(data);
 
     return (
         <ViewLayout title='Links'>

--- a/packages/frontend/app/routes/affiliates/views/LinksView.tsx
+++ b/packages/frontend/app/routes/affiliates/views/LinksView.tsx
@@ -25,6 +25,7 @@ import { CreateReferralCodeModal } from '../components/CreateReferralCode/Create
 import styles from '../affiliates.module.css';
 
 export function LinksView() {
+    console.log('running');
     const allowMultipleAffiliateCodes = false;
     const sessionState = useSession();
     const isConnected = isEstablished(sessionState);
@@ -140,6 +141,7 @@ export function LinksView() {
     const canCreateCode = allowMultipleAffiliateCodes || !hasCreatedCode;
     const createCodeDisabledMessage =
         'Creating multiple referral codes is currently disabled. You can only have one code per wallet.';
+    console.log(data);
 
     return (
         <ViewLayout title='Links'>
@@ -251,7 +253,7 @@ export function LinksView() {
                                             %
                                         </td>
                                         <td className={styles['table-cell']}>
-                                            {entry.clicks.toLocaleString()}
+                                            {entry.clicks ?? '--'}
                                         </td>
                                         <td className={styles['table-cell']}>
                                             {entry.total_users.toLocaleString()}

--- a/packages/frontend/app/routes/affiliates/views/LinksView.tsx
+++ b/packages/frontend/app/routes/affiliates/views/LinksView.tsx
@@ -80,11 +80,11 @@ export function LinksView() {
     const data = affiliateCode
         ? [
               {
-                  code: affiliateCode.code,
-                  created_at: affiliateCode.created_at,
-                  clicks: affiliateCode.clicks,
-                  total_users: affiliateCode.total_users,
-                  total_earnings: affiliateCode.total_earnings,
+                  code: affiliateCode.code ?? '--',
+                  created_at: affiliateCode.created_at ?? '--',
+                  clicks: affiliateCode.clicks ?? '--',
+                  total_users: affiliateCode.total_users ?? '--',
+                  total_earnings: affiliateCode.total_earnings ?? '--',
                   you_percentage: youPercent,
                   invitee_percentage: inviteePercent,
               },

--- a/packages/frontend/app/routes/affiliates/views/LinksView.tsx
+++ b/packages/frontend/app/routes/affiliates/views/LinksView.tsx
@@ -256,7 +256,7 @@ export function LinksView() {
                                             {entry.clicks ?? '--'}
                                         </td>
                                         <td className={styles['table-cell']}>
-                                            {entry.total_users.toLocaleString()}
+                                            {entry.total_users ?? '--'}
                                         </td>
                                         <td
                                             className={styles['table-cell']}
@@ -266,7 +266,12 @@ export function LinksView() {
                                                 fontWeight: 600,
                                             }}
                                         >
-                                            ${formatUSD(entry.total_earnings)}
+                                            $
+                                            {entry.total_earnings
+                                                ? formatUSD(
+                                                      entry.total_earnings,
+                                                  )
+                                                : '--'}
                                         </td>
                                         <td
                                             className={styles['table-cell']}


### PR DESCRIPTION
Fixed a crash on the `Links` tab of the `/v2/affiliates` page due to several unhandled `undefined` values.